### PR TITLE
test: add comprehensive test infrastructure and GitHub Actions validation layer

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+SampleExpoApp/
+SampleRNApp/
+examples/
+coverage/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
 #!/bin/sh
-# Run lint and type check before committing
+# Run lint, type check, and tests before committing
 npm run pre-commit
+npm test

--- a/jest.config.js
+++ b/jest.config.js
@@ -31,10 +31,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: 24,
-      functions: 28,
-      lines: 29,
-      statements: 29,
+      branches: 50,
+      functions: 49,
+      lines: 52,
+      statements: 52,
     },
   },
   
@@ -43,6 +43,7 @@ module.exports = {
     '/node_modules/',
     '/dist/',
     '/SampleRNApp/',
+    '/SampleExpoApp/',
     '/app/',
     '/examples/',
   ],

--- a/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -1,0 +1,962 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration: Full Workflow Generation Pipeline Bitrise — Build output structure matches snapshot 1`] = `
+{
+  "app": {
+    "envs": [
+      {
+        "CI": "true",
+      },
+      {
+        "NODE_OPTIONS": "--max_old_space_size=4096",
+      },
+      {
+        "YARN_ENABLE_IMMUTABLE_INSTALLS": "1",
+      },
+    ],
+  },
+  "default_step_lib_source": "https://github.com/bitrise-io/bitrise-steplib.git",
+  "format_version": 13,
+  "meta": {
+    "bitrise.io": {
+      "machine_type_id": "elite",
+      "stack": "linux-docker-android-22.04",
+    },
+  },
+  "project_type": "react-native",
+  "trigger_map": [
+    {
+      "push_branch": "main",
+      "workflow": "rn-android-build",
+    },
+    {
+      "pull_request_target_branch": "main",
+      "workflow": "rn-android-build",
+    },
+  ],
+  "workflows": {
+    "rn-android-build": {
+      "description": "Build React Native Android app",
+      "meta": {
+        "bitrise.io": {
+          "machine_type_id": "elite",
+          "stack": "linux-docker-android-22.04",
+        },
+      },
+      "steps": [
+        {
+          "git-clone@8": {
+            "title": "Git Clone",
+          },
+        },
+        {
+          "nvm@1": {
+            "inputs": [
+              {
+                "node_version": "20",
+              },
+            ],
+            "title": "Setup Node.js 20",
+          },
+        },
+        {
+          "restore-cache@2": {
+            "inputs": [
+              {
+                "key": "{{ .OS }}-{{ .Arch }}-yarn-cache-{{ checksum "yarn.lock" }}",
+              },
+            ],
+            "title": "Restore yarn cache",
+          },
+        },
+        {
+          "yarn@0": {
+            "inputs": [
+              {
+                "args": "--immutable",
+              },
+            ],
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+yarn tsc --noEmit",
+              },
+            ],
+            "title": "TypeScript Check",
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+yarn lint",
+              },
+            ],
+            "title": "ESLint",
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+yarn test --ci",
+              },
+            ],
+            "title": "Unit Tests",
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+# Check for required directories and files
+echo "🔍 Verifying Android project setup..."
+
+if [ ! -d "android" ]; then
+  echo "❌ Error: Android directory not found"
+  echo "Make sure you're running this workflow from the root"
+  echo "of a React Native project"
+  exit 1
+fi
+
+if [ ! -f "android/gradlew" ]; then
+  echo "⚠️ Warning: Gradle wrapper not found at android/gradlew"
+  echo "Build may fail if Gradle wrapper is not properly set up"
+fi
+
+echo "✅ Android environment looks good"
+
+# Make gradlew executable
+chmod +x android/gradlew
+
+echo "🚀 Starting Android build for debug..."
+
+# Building APK
+echo "Using Gradle task: assembleDebug for debug build with APK output format"
+
+cd android
+./gradlew assembleDebug || {
+  echo "❌ Android build failed"
+  exit 1
+}
+
+cd ..
+
+echo "✅ Android build completed successfully"
+
+# Verify the expected outputs
+if ls android/app/build/outputs/apk/**/*.apk 1> /dev/null 2>&1; then
+  echo "✅ APK files generated successfully"
+else
+  echo "⚠️ Warning: Expected APK files not found. Storage steps may fail."
+fi",
+              },
+            ],
+            "title": "Build Android App",
+          },
+        },
+        {
+          "deploy-to-bitrise-io@2": {
+            "inputs": [
+              {
+                "notify_user_groups": "everyone",
+              },
+              {
+                "is_enable_public_page": "true",
+              },
+            ],
+            "title": "Deploy to Bitrise.io",
+          },
+        },
+        {
+          "save-cache@1": {
+            "inputs": [
+              {
+                "key": "{{ .OS }}-{{ .Arch }}-yarn-cache-{{ checksum "yarn.lock" }}",
+              },
+              {
+                "paths": "node_modules",
+              },
+            ],
+            "title": "Save yarn cache",
+          },
+        },
+      ],
+      "title": "Build Android",
+    },
+  },
+}
+`;
+
+exports[`Integration: Full Workflow Generation Pipeline Bitrise — Static Analysis output structure matches snapshot 1`] = `
+{
+  "app": {
+    "envs": [
+      {
+        "CI": "true",
+      },
+      {
+        "NODE_OPTIONS": "--max_old_space_size=4096",
+      },
+      {
+        "YARN_ENABLE_IMMUTABLE_INSTALLS": "1",
+      },
+    ],
+  },
+  "default_step_lib_source": "https://github.com/bitrise-io/bitrise-steplib.git",
+  "format_version": 13,
+  "meta": {
+    "bitrise.io": {
+      "machine_type_id": "elite",
+      "stack": "linux-docker-android-22.04",
+    },
+  },
+  "project_type": "react-native",
+  "trigger_map": [
+    {
+      "push_branch": "main",
+      "workflow": "rn-static-analysis",
+    },
+    {
+      "pull_request_target_branch": "main",
+      "workflow": "rn-static-analysis",
+    },
+  ],
+  "workflows": {
+    "rn-static-analysis": {
+      "description": "Run static analysis including TypeScript, ESLint, Prettier, and unit tests",
+      "steps": [
+        {
+          "git-clone@8": {
+            "title": "Git Clone",
+          },
+        },
+        {
+          "nvm@1": {
+            "inputs": [
+              {
+                "node_version": "18",
+              },
+            ],
+            "title": "Setup Node.js 18",
+          },
+        },
+        {
+          "restore-cache@2": {
+            "inputs": [
+              {
+                "key": "{{ .OS }}-{{ .Arch }}-yarn-cache-{{ checksum "yarn.lock" }}",
+              },
+            ],
+            "title": "Restore yarn cache",
+          },
+        },
+        {
+          "yarn@0": {
+            "inputs": [
+              {
+                "args": "--immutable",
+              },
+            ],
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+yarn tsc --noEmit",
+              },
+            ],
+            "title": "TypeScript Check",
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+yarn lint",
+              },
+            ],
+            "title": "ESLint Check",
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+yarn format:check",
+              },
+            ],
+            "title": "Prettier Check",
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+yarn test --ci",
+              },
+            ],
+            "title": "Unit Tests",
+          },
+        },
+        {
+          "save-cache@1": {
+            "inputs": [
+              {
+                "key": "{{ .OS }}-{{ .Arch }}-yarn-cache-{{ checksum "yarn.lock" }}",
+              },
+              {
+                "paths": "node_modules",
+              },
+            ],
+            "title": "Save yarn cache",
+          },
+        },
+      ],
+      "title": "React Native Static Analysis",
+    },
+  },
+}
+`;
+
+exports[`Integration: Full Workflow Generation Pipeline GitHub Actions — Build (Android) output structure matches snapshot 1`] = `
+{
+  "env": {},
+  "jobs": {
+    "build-android": {
+      "name": "Build Android Debug",
+      "needs": [
+        "static_analysis",
+      ],
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "name": "Checkout",
+          "uses": "actions/checkout@v4",
+        },
+        {
+          "name": "Setup Node",
+          "uses": "actions/setup-node@v4",
+          "with": {
+            "cache": "yarn",
+            "node-version": 20,
+          },
+        },
+        {
+          "name": "Install",
+          "run": "yarn install --immutable",
+        },
+        {
+          "id": "android-env-check",
+          "name": "Verify Android Environment",
+          "run": "
+# Check for required directories and files
+echo "🔍 Verifying Android project setup..."
+
+if [ ! -d "android" ]; then
+  echo "❌ Error: Android directory not found"
+  echo "Make sure you're running this workflow from the root"
+  echo "of a React Native project"
+  exit 1
+fi
+
+if [ ! -f "android/gradlew" ]; then
+  echo "⚠️ Warning: Gradle wrapper not found at android/gradlew"
+  echo "Build may fail if Gradle wrapper is not properly set up"
+fi
+
+echo "✅ Android environment looks good"
+",
+        },
+        {
+          "name": "Setup Java",
+          "uses": "actions/setup-java@v3",
+          "with": {
+            "cache": "gradle",
+            "distribution": "temurin",
+            "java-version": "17",
+          },
+        },
+        {
+          "name": "Make Gradlew Executable",
+          "run": "chmod +x android/gradlew",
+        },
+        {
+          "id": "android-build",
+          "name": "Run Android Build",
+          "run": "
+echo "🚀 Starting Android build for debug..."
+
+# Check for .env file and use it if exists
+if [ -f ".env" ]; then
+  echo "✅ Found .env file, will be used for the build"
+else
+  echo "⚠️ No .env file found in project root"
+fi
+
+# Run the build with error capture
+echo "Building Android app using official React Native CLI..."
+
+# Using direct Gradle commands for more reliable builds
+echo "Using Gradle task: assembleDebug for debug build with apk output format"
+
+# Using direct Gradle command
+cd android
+./gradlew assembleDebug || {
+  echo "❌ Android build failed"
+  echo "::error::Android build failed. Check logs for details."
+  exit 1
+}
+cd ..
+
+
+echo "✅ Android build completed successfully"
+
+# Verify the expected outputs based on output type
+if ls android/app/build/outputs/apk/**/*.apk 1> /dev/null 2>&1; then
+  echo "✅ APK files generated successfully"
+else
+  echo "⚠️ Warning: Expected APK files not found. Storage steps may fail."
+fi
+",
+        },
+        {
+          "continue-on-error": true,
+          "id": "artifact-upload-android",
+          "if": "success()",
+          "name": "Upload Android Artifact",
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "name": "android-debug-apk",
+            "path": "android/app/build/outputs/apk/**/*.apk",
+            "retention-days": 30,
+          },
+        },
+      ],
+    },
+    "static_analysis": {
+      "name": "Run Static Analysis",
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "name": "Checkout",
+          "uses": "actions/checkout@v4",
+        },
+        {
+          "name": "Setup Node",
+          "uses": "actions/setup-node@v4",
+          "with": {
+            "cache": "yarn",
+            "node-version": 20,
+          },
+        },
+        {
+          "name": "Install",
+          "run": "yarn install --immutable",
+        },
+        {
+          "name": "TypeScript",
+          "run": "yarn tsc --noEmit",
+        },
+        {
+          "name": "ESLint",
+          "run": "yarn lint",
+        },
+        {
+          "name": "Prettier",
+          "run": "yarn format:check",
+        },
+        {
+          "name": "Unit tests",
+          "run": "yarn test --ci",
+        },
+      ],
+    },
+  },
+  "name": "Build Pipeline",
+  "on": {
+    "pull_request": {
+      "branches": [
+        "main",
+      ],
+    },
+    "push": {
+      "branches": [
+        "main",
+      ],
+    },
+  },
+}
+`;
+
+exports[`Integration: Full Workflow Generation Pipeline GitHub Actions — Build (Both platforms) output structure matches snapshot 1`] = `
+{
+  "env": {},
+  "jobs": {
+    "build-android": {
+      "name": "Build Android Debug",
+      "needs": [
+        "static_analysis",
+      ],
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "name": "Checkout",
+          "uses": "actions/checkout@v4",
+        },
+        {
+          "name": "Setup Node",
+          "uses": "actions/setup-node@v4",
+          "with": {
+            "cache": "yarn",
+            "node-version": 20,
+          },
+        },
+        {
+          "name": "Install",
+          "run": "yarn install --immutable",
+        },
+        {
+          "id": "android-env-check",
+          "name": "Verify Android Environment",
+          "run": "
+# Check for required directories and files
+echo "🔍 Verifying Android project setup..."
+
+if [ ! -d "android" ]; then
+  echo "❌ Error: Android directory not found"
+  echo "Make sure you're running this workflow from the root"
+  echo "of a React Native project"
+  exit 1
+fi
+
+if [ ! -f "android/gradlew" ]; then
+  echo "⚠️ Warning: Gradle wrapper not found at android/gradlew"
+  echo "Build may fail if Gradle wrapper is not properly set up"
+fi
+
+echo "✅ Android environment looks good"
+",
+        },
+        {
+          "name": "Setup Java",
+          "uses": "actions/setup-java@v3",
+          "with": {
+            "cache": "gradle",
+            "distribution": "temurin",
+            "java-version": "17",
+          },
+        },
+        {
+          "name": "Make Gradlew Executable",
+          "run": "chmod +x android/gradlew",
+        },
+        {
+          "id": "android-build",
+          "name": "Run Android Build",
+          "run": "
+echo "🚀 Starting Android build for debug..."
+
+# Check for .env file and use it if exists
+if [ -f ".env" ]; then
+  echo "✅ Found .env file, will be used for the build"
+else
+  echo "⚠️ No .env file found in project root"
+fi
+
+# Run the build with error capture
+echo "Building Android app using official React Native CLI..."
+
+# Using direct Gradle commands for more reliable builds
+echo "Using Gradle task: assembleDebug for debug build with apk output format"
+
+# Using direct Gradle command
+cd android
+./gradlew assembleDebug || {
+  echo "❌ Android build failed"
+  echo "::error::Android build failed. Check logs for details."
+  exit 1
+}
+cd ..
+
+
+echo "✅ Android build completed successfully"
+
+# Verify the expected outputs based on output type
+if ls android/app/build/outputs/apk/**/*.apk 1> /dev/null 2>&1; then
+  echo "✅ APK files generated successfully"
+else
+  echo "⚠️ Warning: Expected APK files not found. Storage steps may fail."
+fi
+",
+        },
+        {
+          "continue-on-error": true,
+          "id": "artifact-upload-android",
+          "if": "success()",
+          "name": "Upload Android Artifact",
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "name": "android-debug-apk",
+            "path": "android/app/build/outputs/apk/**/*.apk",
+            "retention-days": 30,
+          },
+        },
+      ],
+    },
+    "build-ios": {
+      "name": "Build Ios Debug",
+      "needs": [
+        "static_analysis",
+      ],
+      "runs-on": "macos-latest",
+      "steps": [
+        {
+          "name": "Checkout",
+          "uses": "actions/checkout@v4",
+        },
+        {
+          "name": "Setup Node",
+          "uses": "actions/setup-node@v4",
+          "with": {
+            "cache": "yarn",
+            "node-version": 20,
+          },
+        },
+        {
+          "name": "Install",
+          "run": "yarn install --immutable",
+        },
+        {
+          "id": "ios-env-check",
+          "name": "Verify iOS Environment",
+          "run": "
+# Check for required directories and files
+echo "🔍 Verifying iOS project setup..."
+
+if [ ! -d "ios" ]; then
+  echo "❌ Error: iOS directory not found"
+  echo "Make sure you're running this workflow from the root"
+  echo "of a React Native project"
+  exit 1
+fi
+
+if [ ! -f "ios/Podfile" ]; then
+  echo "❌ Error: Podfile not found"
+  echo "iOS build will likely fail without a valid Podfile"
+  exit 1
+fi
+
+echo "✅ iOS environment looks good"
+",
+        },
+        {
+          "name": "Setup Ruby/CocoaPods",
+          "uses": "ruby/setup-ruby@v1",
+          "with": {
+            "bundler-cache": "true",
+            "ruby-version": "3.0",
+            "working-directory": "ios",
+          },
+        },
+        {
+          "id": "pod-install",
+          "name": "Install CocoaPods",
+          "run": "
+echo "📦 Installing CocoaPods dependencies..."
+cd ios
+pod install || {
+  echo "❌ CocoaPods installation failed"
+  echo "::error::CocoaPods installation failed."
+  echo "Check for valid Podfile and Pod specs."
+  exit 1
+}
+echo "✅ CocoaPods installation successful"
+",
+        },
+        {
+          "id": "ios-build",
+          "name": "Run iOS Build",
+          "run": "
+echo "🚀 Starting iOS build for debug..."
+
+# Check for .env file and use it if exists
+if [ -f ".env" ]; then
+  echo "✅ Found .env file, will be used for the build"
+else
+  echo "⚠️ No .env file found in project root"
+fi
+
+# Run the build with error capture
+echo "Building iOS app using direct Xcode commands..."
+
+# Determine the configuration based on variant
+CONFIG=$(echo "debug" | tr '[:upper:]' '[:lower:]')
+if [ "$CONFIG" == "debug" ]; then
+  CONFIGURATION="Debug"
+else
+  CONFIGURATION="Release"
+fi
+
+echo "Using Xcode build with configuration: $CONFIGURATION"
+
+# Extract project name from xcworkspace directory
+WORKSPACE_PATH=$(find ios -name "*.xcworkspace" -type d | head -n 1)
+if [ -z "$WORKSPACE_PATH" ]; then
+  echo "❌ No .xcworkspace found in ios directory"
+  exit 1
+fi
+
+PROJECT_NAME=$(basename "$WORKSPACE_PATH" .xcworkspace)
+echo "Detected project: $PROJECT_NAME"
+
+# Using direct Xcode command for more reliable builds
+xcodebuild   -workspace "ios/$PROJECT_NAME.xcworkspace"   -scheme "$PROJECT_NAME"   -configuration "$CONFIGURATION"   -derivedDataPath ios/build   -destination 'generic/platform=iOS'   -archivePath "ios/build/$PROJECT_NAME.xcarchive"   archive || {
+    echo "❌ iOS build failed"
+    echo "::error::Xcode build failed. Check logs for details."
+    exit 1
+  }
+
+# Export IPA for distribution
+xcodebuild   -exportArchive   -archivePath "ios/build/$PROJECT_NAME.xcarchive"   -exportPath "ios/build/output"   -exportOptionsPlist "ios/ExportOptions.plist" || {
+    echo "❌ iOS export failed"
+    echo "::warning::Xcode export failed. This might be due to missing ExportOptions.plist file."
+    
+    # Create a basic ExportOptions.plist if it doesn't exist
+    if [ ! -f "ios/ExportOptions.plist" ]; then
+      echo "Creating default ExportOptions.plist file..."
+      cat > ios/ExportOptions.plist << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>$([ "$CONFIG" == "debug" ] && echo "development" || echo "app-store")</string>
+    <key>teamID</key>
+    <string>TEAM_ID</string>
+</dict>
+</plist>
+EOF
+      
+      # Try export again
+      xcodebuild         -exportArchive         -archivePath "ios/build/$PROJECT_NAME.xcarchive"         -exportPath "ios/build/output"         -exportOptionsPlist "ios/ExportOptions.plist" || {
+          echo "❌ iOS export failed again"
+          echo "::error::Xcode export failed even with default ExportOptions.plist. Check logs for details."
+          exit 1
+        }
+    else
+      echo "ExportOptions.plist exists but export failed. Check the file format and content."
+      exit 1
+    fi
+  }
+
+echo "✅ iOS build completed successfully"
+
+# Verify the expected outputs exist
+if ls ios/build/output/*.ipa 1> /dev/null 2>&1; then
+  echo "✅ IPA files generated successfully"
+else
+  echo "⚠️ Warning: Expected IPA files not found. Storage steps may fail."
+fi
+",
+        },
+        {
+          "continue-on-error": true,
+          "id": "artifact-upload-ios",
+          "if": "success()",
+          "name": "Upload iOS Artifact",
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "name": "ios-debug-\${{ github.run_id }}",
+            "path": "ios/build/Build/Products/**/*.ipa",
+            "retention-days": 30,
+          },
+        },
+      ],
+    },
+    "static_analysis": {
+      "name": "Run Static Analysis",
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "name": "Checkout",
+          "uses": "actions/checkout@v4",
+        },
+        {
+          "name": "Setup Node",
+          "uses": "actions/setup-node@v4",
+          "with": {
+            "cache": "yarn",
+            "node-version": 20,
+          },
+        },
+        {
+          "name": "Install",
+          "run": "yarn install --immutable",
+        },
+        {
+          "name": "TypeScript",
+          "run": "yarn tsc --noEmit",
+        },
+        {
+          "name": "ESLint",
+          "run": "yarn lint",
+        },
+        {
+          "name": "Prettier",
+          "run": "yarn format:check",
+        },
+        {
+          "name": "Unit tests",
+          "run": "yarn test --ci",
+        },
+      ],
+    },
+  },
+  "name": "Build Pipeline",
+  "on": {
+    "pull_request": {
+      "branches": [
+        "main",
+      ],
+    },
+    "push": {
+      "branches": [
+        "main",
+      ],
+    },
+  },
+}
+`;
+
+exports[`Integration: Full Workflow Generation Pipeline GitHub Actions — Static Analysis output structure matches snapshot 1`] = `
+{
+  "env": {
+    "GITHUB_TOKEN": "\${{ secrets.GITHUB_TOKEN }}",
+  },
+  "jobs": {
+    "static_analysis": {
+      "name": "Run Static Analysis",
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "name": "Checkout",
+          "uses": "actions/checkout@v4",
+        },
+        {
+          "name": "Setup Node",
+          "uses": "actions/setup-node@v4",
+          "with": {
+            "cache": "yarn",
+            "node-version": 20,
+          },
+        },
+        {
+          "name": "Install",
+          "run": "yarn install --immutable",
+        },
+        {
+          "name": "TypeScript",
+          "run": "yarn tsc --noEmit",
+        },
+        {
+          "name": "ESLint",
+          "run": "yarn lint",
+        },
+        {
+          "name": "Prettier",
+          "run": "yarn format:check",
+        },
+        {
+          "name": "Unit tests",
+          "run": "yarn test --ci",
+        },
+        {
+          "id": "static-analysis-source",
+          "name": "Determine PR Status",
+          "run": "
+# Determine if this is a PR or a direct push
+EVENT_NAME="\${{ github.event_name }}"
+if [[ "$EVENT_NAME" == "pull_request" ]] || [[ "$EVENT_NAME" == "pull_request_target" ]]; then
+  # This is a PR - set output flag
+  echo "is_pr=true" >> $GITHUB_OUTPUT
+  echo "📌 Running static analysis on PR #\${{ github.event.pull_request.number }} from branch \${{ github.head_ref }}"
+else
+  # This is a direct push - set output flag
+  echo "is_pr=false" >> $GITHUB_OUTPUT
+  echo "📌 Running static analysis on branch \${{ github.ref_name }}"
+fi
+",
+        },
+        {
+          "env": {
+            "GH_TOKEN": "\${{ secrets.GITHUB_TOKEN }}",
+          },
+          "if": "steps.static-analysis-source.outputs.is_pr == 'true'",
+          "name": "Add Static Analysis PR Comment",
+          "run": "# Create comment message
+MESSAGE="## 📊 Static Analysis Results
+
+\${{ job.status == 'success' && '✅ All static analysis checks passed!' || '❌ Some static analysis checks failed!' }}
+
+### Build Information
+- **Repository**: \${{ github.repository }}
+- **Branch**: \${{ github.head_ref }}
+- **Commit**: \${{ github.sha }}
+- **Workflow**: \${{ github.workflow }}
+
+> Static analysis completed via React Native CI Workflow Builder"
+
+# Check if comment already exists and update it
+PR_NUM="\${{ github.event.number }}"
+SEARCH_TEXT="Static Analysis Results"
+echo "Creating new comment..."
+gh pr comment $PR_NUM --body "$MESSAGE"
+",
+        },
+      ],
+    },
+  },
+  "name": "Static Analysis",
+  "on": {
+    "pull_request": {
+      "branches": [
+        "main",
+      ],
+    },
+    "push": {
+      "branches": [
+        "main",
+      ],
+    },
+  },
+}
+`;

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -1,0 +1,479 @@
+/**
+ * Integration tests: full config → YAML → parse back → assert structure
+ *
+ * No mocks used. Tests the complete generation pipeline end-to-end.
+ * Imports from src/index.ts so all built-in presets are auto-registered.
+ */
+import * as yaml from 'js-yaml';
+import { generateWorkflow } from '../index';
+
+describe('Integration: Full Workflow Generation Pipeline', () => {
+  // ─── GitHub Actions: Static Analysis ─────────────────────────────────────
+
+  describe('GitHub Actions — Static Analysis', () => {
+    it('generates valid parseable YAML with yarn', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: { platform: 'github', packageManager: 'yarn', nodeVersions: [20] },
+      });
+
+      expect(typeof yamlStr).toBe('string');
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+
+      expect(parsed.name).toBeDefined();
+      expect(parsed.on).toBeDefined();
+      expect(parsed.jobs).toBeDefined();
+      expect(parsed.jobs.static_analysis).toBeDefined();
+      expect(parsed.jobs.static_analysis['runs-on']).toBe('ubuntu-latest');
+      expect(Array.isArray(parsed.jobs.static_analysis.steps)).toBe(true);
+      expect(parsed.jobs.static_analysis.steps.length).toBeGreaterThan(0);
+    });
+
+    it('generates valid parseable YAML with npm', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: { platform: 'github', packageManager: 'npm', nodeVersions: [18] },
+      });
+
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      const steps = parsed.jobs.static_analysis.steps;
+
+      expect(steps.some((s: any) => s.run === 'npm ci')).toBe(true);
+    });
+
+    it('includes TypeScript step by default', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: { platform: 'github' },
+      });
+
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      const steps = parsed.jobs.static_analysis.steps;
+
+      expect(steps.some((s: any) => s.name === 'TypeScript')).toBe(true);
+    });
+
+    it('currently ignores staticAnalysis options due to validator dropping them (bug H — to be fixed in PR 2)', () => {
+      // Bug H: validateWorkflowOptionsSchema drops the `staticAnalysis` field.
+      // As a result, the preset falls back to defaults (all checks enabled)
+      // even when the caller explicitly disables TypeScript.
+      // After PR 2 fix, this test should be updated to assert TypeScript is excluded.
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: {
+          platform: 'github',
+          staticAnalysis: { typescript: false, eslint: true, prettier: true, unitTests: true },
+        },
+      });
+
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      const steps = parsed.jobs.static_analysis.steps;
+
+      // Current broken behavior: TypeScript step is still included despite being disabled
+      expect(steps.some((s: any) => s.name === 'TypeScript')).toBe(true);
+    });
+
+    it('includes all default analysis steps', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: { platform: 'github', packageManager: 'yarn' },
+      });
+
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      const stepNames = parsed.jobs.static_analysis.steps.map((s: any) => s.name);
+
+      expect(stepNames).toContain('TypeScript');
+      expect(stepNames).toContain('ESLint');
+      expect(stepNames).toContain('Prettier');
+      expect(stepNames).toContain('Unit tests');
+    });
+
+    it('output structure matches snapshot', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: { platform: 'github', packageManager: 'yarn', nodeVersions: [20] },
+      });
+
+      expect(yaml.load(yamlStr)).toMatchSnapshot();
+    });
+  });
+
+  // ─── GitHub Actions: Build — Android ─────────────────────────────────────
+
+  describe('GitHub Actions — Build (Android)', () => {
+    const androidConfig = {
+      kind: 'build',
+      options: {
+        platform: 'github' as const,
+        packageManager: 'yarn' as const,
+        build: {
+          platform: 'android' as const,
+          variant: 'debug' as const,
+          storage: 'github' as const,
+          notification: 'none' as const,
+        },
+      },
+    };
+
+    it('generates valid parseable YAML', () => {
+      const { yaml: yamlStr } = generateWorkflow(androidConfig);
+
+      expect(typeof yamlStr).toBe('string');
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+
+      expect(parsed.name).toBeDefined();
+      expect(parsed.on).toBeDefined();
+      expect(parsed.jobs).toBeDefined();
+      expect(parsed.jobs['build-android']).toBeDefined();
+      expect(parsed.jobs['build-android']['runs-on']).toBe('ubuntu-latest');
+      expect(Array.isArray(parsed.jobs['build-android'].steps)).toBe(true);
+    });
+
+    it('does not include iOS job for android-only build', () => {
+      const { yaml: yamlStr } = generateWorkflow(androidConfig);
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+
+      expect(parsed.jobs['build-ios']).toBeUndefined();
+    });
+
+    it('generates a secretsSummary', () => {
+      const { secretsSummary } = generateWorkflow(androidConfig);
+
+      expect(secretsSummary).toBeDefined();
+    });
+
+    it('output structure matches snapshot', () => {
+      const { yaml: yamlStr } = generateWorkflow(androidConfig);
+
+      expect(yaml.load(yamlStr)).toMatchSnapshot();
+    });
+  });
+
+  // ─── GitHub Actions: Build — Both Platforms ───────────────────────────────
+
+  describe('GitHub Actions — Build (Both platforms)', () => {
+    it('generates both build-android and build-ios jobs', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'build',
+        options: {
+          platform: 'github',
+          build: {
+            platform: 'both',
+            variant: 'debug',
+            storage: 'github',
+            notification: 'none',
+          },
+        },
+      });
+
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+
+      expect(parsed.jobs['build-android']).toBeDefined();
+      expect(parsed.jobs['build-ios']).toBeDefined();
+      expect(parsed.jobs['build-android']['runs-on']).toBe('ubuntu-latest');
+      expect(parsed.jobs['build-ios']['runs-on']).toBe('macos-latest');
+    });
+
+    it('output structure matches snapshot', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'build',
+        options: {
+          platform: 'github',
+          build: {
+            platform: 'both',
+            variant: 'debug',
+            storage: 'github',
+            notification: 'none',
+          },
+        },
+      });
+
+      expect(yaml.load(yamlStr)).toMatchSnapshot();
+    });
+  });
+
+  // ─── GitHub Actions: Build — Release variant ─────────────────────────────
+
+  describe('GitHub Actions — Build (Release)', () => {
+    it('generates a build workflow for release variant', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'build',
+        options: {
+          platform: 'github',
+          build: {
+            platform: 'android',
+            variant: 'release',
+            storage: 'github',
+            notification: 'none',
+          },
+        },
+      });
+
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      expect(parsed.jobs['build-android']).toBeDefined();
+    });
+  });
+
+  // ─── Bitrise: Static Analysis ─────────────────────────────────────────────
+
+  describe('Bitrise — Static Analysis', () => {
+    it('generates valid parseable Bitrise YAML', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: { platform: 'bitrise', packageManager: 'yarn' },
+      });
+
+      expect(typeof yamlStr).toBe('string');
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+
+      expect(parsed.format_version).toBe(13);
+      expect(parsed.workflows).toBeDefined();
+      expect(parsed.workflows['rn-static-analysis']).toBeDefined();
+      expect(Array.isArray(parsed.workflows['rn-static-analysis'].steps)).toBe(true);
+      expect(parsed.workflows['rn-static-analysis'].steps.length).toBeGreaterThan(0);
+    });
+
+    it('output structure matches snapshot', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: { platform: 'bitrise', packageManager: 'yarn' },
+      });
+
+      expect(yaml.load(yamlStr)).toMatchSnapshot();
+    });
+  });
+
+  // ─── Bitrise: Build ───────────────────────────────────────────────────────
+
+  describe('Bitrise — Build', () => {
+    const bitriseAndroidConfig = {
+      kind: 'build',
+      options: {
+        platform: 'bitrise' as const,
+        build: {
+          platform: 'android' as const,
+          variant: 'debug' as const,
+          storage: 'bitrise' as const,
+          notification: 'none' as const,
+        },
+      },
+    };
+
+    it('generates valid parseable Bitrise build YAML', () => {
+      const { yaml: yamlStr } = generateWorkflow(bitriseAndroidConfig);
+
+      expect(typeof yamlStr).toBe('string');
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+
+      expect(parsed.format_version).toBeDefined();
+      expect(typeof parsed.format_version).toBe('number');
+      expect(parsed.workflows).toBeDefined();
+    });
+
+    it('output structure matches snapshot', () => {
+      const { yaml: yamlStr } = generateWorkflow(bitriseAndroidConfig);
+
+      expect(yaml.load(yamlStr)).toMatchSnapshot();
+    });
+  });
+
+  // ─── GitHub Actions: Expo Framework ──────────────────────────────────────
+
+  describe('GitHub Actions — Expo Build', () => {
+    it('generates a workflow for expo android build', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'build',
+        options: {
+          platform: 'github',
+          framework: 'expo',
+          build: {
+            platform: 'android',
+            variant: 'debug',
+            storage: 'github',
+            notification: 'none',
+          },
+        },
+      });
+
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      expect(parsed.jobs['build-android']).toBeDefined();
+    });
+
+    it('currently falls back to react-native project_type for expo (bug H — framework dropped by validator)', () => {
+      // Bug H: validateWorkflowOptionsSchema does not pass `framework` through.
+      // After PR 2 fix, parsed.project_type should be 'expo'.
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: {
+          platform: 'bitrise',
+          framework: 'expo',
+          packageManager: 'yarn',
+        },
+      });
+
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      // Current broken behavior: framework is dropped → falls back to react-native
+      expect(parsed.project_type).toBe('react-native');
+    });
+  });
+
+  // ─── nodeVersions: currently ignores all but first (bug 1.2 documented) ──
+
+  describe('nodeVersions handling (bug 1.2 — matrix not emitted)', () => {
+    it('uses only the first nodeVersion in the setup step (current broken behavior)', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: {
+          platform: 'github',
+          nodeVersions: [18, 20, 22],
+        },
+      });
+
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      const setupNode = parsed.jobs.static_analysis.steps.find(
+        (s: any) => s.name === 'Setup Node'
+      );
+
+      // Bug 1.2: only first node version used, no matrix strategy emitted
+      // After fix: should have strategy.matrix.node: [18, 20, 22]
+      expect(setupNode?.with?.['node-version']).toBe(18);
+      expect(parsed.jobs.static_analysis.strategy).toBeUndefined();
+    });
+  });
+
+  // ─── Custom triggers ──────────────────────────────────────────────────────
+
+  describe('Custom triggers', () => {
+    it('uses custom push branches', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: {
+          platform: 'github',
+          triggers: {
+            push: { branches: ['develop', 'main'] },
+          },
+        },
+      });
+
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      expect(parsed.on.push?.branches).toEqual(
+        expect.arrayContaining(['develop', 'main'])
+      );
+    });
+
+    it('includes workflowDispatch trigger when set', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: {
+          platform: 'github',
+          triggers: { workflowDispatch: true },
+        },
+      });
+
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      expect(parsed.on.workflow_dispatch).toBeDefined();
+    });
+  });
+
+  // ─── Package managers ─────────────────────────────────────────────────────
+
+  describe('npm package manager in build preset', () => {
+    it('generates a valid build workflow using npm', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'build',
+        options: {
+          platform: 'github',
+          packageManager: 'npm',
+          build: {
+            platform: 'android',
+            variant: 'debug',
+            storage: 'github',
+            notification: 'none',
+          },
+        },
+      });
+
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      expect(parsed.jobs['build-android']).toBeDefined();
+    });
+  });
+
+  // ─── Android output type ──────────────────────────────────────────────────
+
+  describe('Android output type (bug C — androidOutputType dropped by validator)', () => {
+    it('currently falls back to apk regardless of AAB selection (known bug C)', () => {
+      // Bug C: validateBuildSchema drops androidOutputType.
+      // After PR 2 fix, the AAB gradle task should appear in the generated steps.
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'build',
+        options: {
+          platform: 'github',
+          build: {
+            platform: 'android',
+            variant: 'release',
+            storage: 'github',
+            notification: 'none',
+            androidOutputType: 'aab',
+          },
+        },
+      });
+
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      // Workflow generates fine even if output type falls back
+      expect(parsed.jobs['build-android']).toBeDefined();
+    });
+  });
+
+  // ─── Error cases ──────────────────────────────────────────────────────────
+
+  describe('Error handling', () => {
+    it('throws for an unknown preset kind', () => {
+      expect(() =>
+        generateWorkflow({ kind: 'nonexistent-preset' })
+      ).toThrow();
+    });
+
+    it('throws when build options are missing for build preset', () => {
+      expect(() =>
+        generateWorkflow({
+          kind: 'build',
+          options: { platform: 'github' },
+        })
+      ).toThrow();
+    });
+
+    it('throws for invalid platform in build options', () => {
+      expect(() =>
+        generateWorkflow({
+          kind: 'build',
+          options: {
+            platform: 'github',
+            build: {
+              platform: 'invalid' as any,
+              variant: 'debug',
+              storage: 'github',
+              notification: 'none',
+            },
+          },
+        })
+      ).toThrow();
+    });
+
+    it('throws for invalid storage value', () => {
+      expect(() =>
+        generateWorkflow({
+          kind: 'build',
+          options: {
+            platform: 'github',
+            build: {
+              platform: 'android',
+              variant: 'debug',
+              storage: 'invalid-storage' as any,
+              notification: 'none',
+            },
+          },
+        })
+      ).toThrow();
+    });
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,6 +55,14 @@ program
     '-v, --validate-only',
     'Only validate the configuration without generating files'
   )
+  .option(
+    '--validate-actionlint',
+    'Run actionlint static analysis on the generated GitHub Actions workflow (auto-installs actionlint if needed)'
+  )
+  .option(
+    '--validate-act',
+    'Run act --list on the generated GitHub Actions workflow to verify it is parseable by act (requires act to be installed)'
+  )
   .action(async (preset = 'build', options) => {
     try {
       // Default config
@@ -146,6 +154,34 @@ program
           const result = writeWorkflowFile(config);
           filePath = result.filePath;
           console.log(`✅ Workflow written to ${filePath}`);
+        }
+
+        // Post-generation GitHub Actions validation (GitHub platform only)
+        const isGitHubPlatform =
+          !config.options?.platform || config.options?.platform === 'github';
+
+        if (isGitHubPlatform && (options.validateActionlint || options.validateAct)) {
+          const { validateWithActionlint, validateWithAct } = await import('./validation/yaml');
+
+          if (options.validateActionlint) {
+            console.log('🔍 Running actionlint static analysis...');
+            try {
+              await validateWithActionlint(filePath, true);
+            } catch (e) {
+              console.error(`❌ actionlint: ${(e as Error).message}`);
+              process.exit(1);
+            }
+          }
+
+          if (options.validateAct) {
+            console.log('🔍 Running act --list validation...');
+            try {
+              await validateWithAct(filePath);
+            } catch (e) {
+              console.error(`❌ act: ${(e as Error).message}`);
+              process.exit(1);
+            }
+          }
         }
       } catch (error) {
         console.error(
@@ -240,6 +276,40 @@ program
       }
     } catch (error) {
       console.error(`❌ Error: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+// GitHub Actions validate command
+program
+  .command('github-validate [file]')
+  .description(
+    'Validate a GitHub Actions workflow YAML file using actionlint (static analysis) and optionally act'
+  )
+  .option(
+    '--act',
+    'Also run act --list to verify the workflow is parseable by act (requires act to be installed)'
+  )
+  .action(async (file = '.github/workflows/build.yaml', options) => {
+    try {
+      const { validateWithActionlint, validateWithAct } = await import('./validation/yaml');
+
+      if (!fs.existsSync(file)) {
+        console.error(`❌ Error: File not found: ${file}`);
+        process.exit(1);
+      }
+
+      console.log('🔍 Running actionlint static analysis...');
+      await validateWithActionlint(file, true);
+      console.log(`✅ ${file} passes actionlint static analysis`);
+
+      if (options.act) {
+        console.log('🔍 Running act --list validation...');
+        await validateWithAct(file);
+        console.log(`✅ ${file} is parseable by act`);
+      }
+    } catch (error) {
+      console.error(`❌ ${(error as Error).message}`);
       process.exit(1);
     }
   });

--- a/src/helpers/notifications.ts
+++ b/src/helpers/notifications.ts
@@ -9,12 +9,13 @@ interface NotificationStepConfig {
 }
 
 /**
- * Creates a GitHub CLI authorization step
- * GitHub CLI is pre-installed on GitHub Actions runners, so we only need to authorize it.
+ * Creates a GitHub CLI authorization step.
+ * GitHub CLI is pre-installed on GitHub Actions runners.
  */
-function createGitHubCLIInstallationStep(): GitHubStep {
+function createGitHubCLIInstallationStep(stepId: string): GitHubStep {
   return {
     name: 'Setup GitHub CLI',
+    if: `steps.${stepId}.outputs.is_pr == 'true'`,
     run:
       '# GitHub CLI is pre-installed on GitHub Actions runners\n' +
       'echo "Using pre-installed GitHub CLI"\n' +
@@ -71,15 +72,6 @@ else
 fi
 `,
   };
-}
-
-/**
- * Creates a conditional CLI installation step
- */
-function createConditionalCLIInstallationStep(stepId: string): GitHubStep {
-  const cliInstallStep = createGitHubCLIInstallationStep();
-  cliInstallStep.if = `steps.${stepId}.outputs.is_pr == 'true'`;
-  return cliInstallStep;
 }
 
 /**
@@ -358,6 +350,9 @@ function createPRCommentNotificationSteps(
       context: 'build',
     })
   );
+
+  // Add GitHub CLI setup step (only runs when it's a PR)
+  steps.push(createGitHubCLIInstallationStep(stepId));
 
   // Add the provided PR comment step
   steps.push(prCommentStep);

--- a/src/helpers/storage.ts
+++ b/src/helpers/storage.ts
@@ -74,11 +74,11 @@ const storageHelpers = {
           if: 'success()',
           uses: 'wzieba/Firebase-Distribution-Github-Action@v1.4.0',
           with: {
-            appId: '\${{ secrets.FIREBASE_APP_ID_ANDROID }}',
-            serviceCredentialsFileContent: '\${{ secrets.FIREBASE_SERVICE_ACCOUNT }}',
+            appId: '${{ secrets.FIREBASE_APP_ID_ANDROID }}',
+            serviceCredentialsFileContent: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}',
             file: apkPaths[0],
-            releaseNotes: 'Branch: \${{ github.head_ref || github.ref_name }}\nCommit: \${{ github.sha }}\nBuild: \${{ github.run_id }}',
-            groups: '\${{ secrets.FIREBASE_TEST_GROUPS || \'testers\' }}',
+            releaseNotes: 'Branch: ${{ github.head_ref || github.ref_name }}\nCommit: ${{ github.sha }}\nBuild: ${{ github.run_id }}',
+            groups: "${{ secrets.FIREBASE_TEST_GROUPS || 'testers' }}",
           },
         },
       ];

--- a/src/presets/__tests__/__snapshots__/bitriseBuildPreset.test.ts.snap
+++ b/src/presets/__tests__/__snapshots__/bitriseBuildPreset.test.ts.snap
@@ -1,0 +1,488 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildBitriseBuildPipeline output matches snapshot for android debug with yarn 1`] = `
+{
+  "app": {
+    "envs": [
+      {
+        "CI": "true",
+      },
+      {
+        "NODE_OPTIONS": "--max_old_space_size=4096",
+      },
+      {
+        "YARN_ENABLE_IMMUTABLE_INSTALLS": "1",
+      },
+    ],
+  },
+  "default_step_lib_source": "https://github.com/bitrise-io/bitrise-steplib.git",
+  "format_version": 13,
+  "meta": {
+    "bitrise.io": {
+      "machine_type_id": "elite",
+      "stack": "linux-docker-android-22.04",
+    },
+  },
+  "project_type": "react-native",
+  "trigger_map": [
+    {
+      "push_branch": "main",
+      "workflow": "rn-android-build",
+    },
+    {
+      "pull_request_target_branch": "main",
+      "workflow": "rn-android-build",
+    },
+  ],
+  "workflows": {
+    "rn-android-build": {
+      "description": "Build React Native Android app",
+      "meta": {
+        "bitrise.io": {
+          "machine_type_id": "elite",
+          "stack": "linux-docker-android-22.04",
+        },
+      },
+      "steps": [
+        {
+          "git-clone@8": {
+            "title": "Git Clone",
+          },
+        },
+        {
+          "nvm@1": {
+            "inputs": [
+              {
+                "node_version": "20",
+              },
+            ],
+            "title": "Setup Node.js 20",
+          },
+        },
+        {
+          "restore-cache@2": {
+            "inputs": [
+              {
+                "key": "{{ .OS }}-{{ .Arch }}-yarn-cache-{{ checksum "yarn.lock" }}",
+              },
+            ],
+            "title": "Restore yarn cache",
+          },
+        },
+        {
+          "yarn@0": {
+            "inputs": [
+              {
+                "args": "--immutable",
+              },
+            ],
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+# Check for required directories and files
+echo "🔍 Verifying Android project setup..."
+
+if [ ! -d "android" ]; then
+  echo "❌ Error: Android directory not found"
+  echo "Make sure you're running this workflow from the root"
+  echo "of a React Native project"
+  exit 1
+fi
+
+if [ ! -f "android/gradlew" ]; then
+  echo "⚠️ Warning: Gradle wrapper not found at android/gradlew"
+  echo "Build may fail if Gradle wrapper is not properly set up"
+fi
+
+echo "✅ Android environment looks good"
+
+# Make gradlew executable
+chmod +x android/gradlew
+
+echo "🚀 Starting Android build for debug..."
+
+# Building APK
+echo "Using Gradle task: assembleDebug for debug build with APK output format"
+
+cd android
+./gradlew assembleDebug || {
+  echo "❌ Android build failed"
+  exit 1
+}
+
+cd ..
+
+echo "✅ Android build completed successfully"
+
+# Verify the expected outputs
+if ls android/app/build/outputs/apk/**/*.apk 1> /dev/null 2>&1; then
+  echo "✅ APK files generated successfully"
+else
+  echo "⚠️ Warning: Expected APK files not found. Storage steps may fail."
+fi",
+              },
+            ],
+            "title": "Build Android App",
+          },
+        },
+        {
+          "deploy-to-bitrise-io@2": {
+            "inputs": [
+              {
+                "notify_user_groups": "everyone",
+              },
+              {
+                "is_enable_public_page": "true",
+              },
+            ],
+            "title": "Deploy to Bitrise.io",
+          },
+        },
+        {
+          "save-cache@1": {
+            "inputs": [
+              {
+                "key": "{{ .OS }}-{{ .Arch }}-yarn-cache-{{ checksum "yarn.lock" }}",
+              },
+              {
+                "paths": "node_modules",
+              },
+            ],
+            "title": "Save yarn cache",
+          },
+        },
+      ],
+      "title": "Build Android",
+    },
+  },
+}
+`;
+
+exports[`buildBitriseBuildPipeline output matches snapshot for both platforms 1`] = `
+{
+  "app": {
+    "envs": [
+      {
+        "CI": "true",
+      },
+      {
+        "NODE_OPTIONS": "--max_old_space_size=4096",
+      },
+      {
+        "YARN_ENABLE_IMMUTABLE_INSTALLS": "1",
+      },
+    ],
+  },
+  "default_step_lib_source": "https://github.com/bitrise-io/bitrise-steplib.git",
+  "format_version": 13,
+  "meta": {
+    "bitrise.io": {
+      "machine_type_id": "g2-m1.8core",
+      "stack": "osx-xcode-15.3.x-ventura",
+    },
+  },
+  "project_type": "react-native",
+  "trigger_map": [
+    {
+      "push_branch": "main",
+      "workflow": "rn-build-all-platforms",
+    },
+    {
+      "pull_request_target_branch": "main",
+      "workflow": "rn-build-all-platforms",
+    },
+  ],
+  "workflows": {
+    "rn-android-build": {
+      "description": "Build React Native Android app",
+      "meta": {
+        "bitrise.io": {
+          "machine_type_id": "elite",
+          "stack": "linux-docker-android-22.04",
+        },
+      },
+      "steps": [
+        {
+          "git-clone@8": {
+            "title": "Git Clone",
+          },
+        },
+        {
+          "nvm@1": {
+            "inputs": [
+              {
+                "node_version": "20",
+              },
+            ],
+            "title": "Setup Node.js 20",
+          },
+        },
+        {
+          "restore-cache@2": {
+            "inputs": [
+              {
+                "key": "{{ .OS }}-{{ .Arch }}-yarn-cache-{{ checksum "yarn.lock" }}",
+              },
+            ],
+            "title": "Restore yarn cache",
+          },
+        },
+        {
+          "yarn@0": {
+            "inputs": [
+              {
+                "args": "--immutable",
+              },
+            ],
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+# Check for required directories and files
+echo "🔍 Verifying Android project setup..."
+
+if [ ! -d "android" ]; then
+  echo "❌ Error: Android directory not found"
+  echo "Make sure you're running this workflow from the root"
+  echo "of a React Native project"
+  exit 1
+fi
+
+if [ ! -f "android/gradlew" ]; then
+  echo "⚠️ Warning: Gradle wrapper not found at android/gradlew"
+  echo "Build may fail if Gradle wrapper is not properly set up"
+fi
+
+echo "✅ Android environment looks good"
+
+# Make gradlew executable
+chmod +x android/gradlew
+
+echo "🚀 Starting Android build for debug..."
+
+# Building APK
+echo "Using Gradle task: assembleDebug for debug build with APK output format"
+
+cd android
+./gradlew assembleDebug || {
+  echo "❌ Android build failed"
+  exit 1
+}
+
+cd ..
+
+echo "✅ Android build completed successfully"
+
+# Verify the expected outputs
+if ls android/app/build/outputs/apk/**/*.apk 1> /dev/null 2>&1; then
+  echo "✅ APK files generated successfully"
+else
+  echo "⚠️ Warning: Expected APK files not found. Storage steps may fail."
+fi",
+              },
+            ],
+            "title": "Build Android App",
+          },
+        },
+        {
+          "deploy-to-bitrise-io@2": {
+            "inputs": [
+              {
+                "notify_user_groups": "everyone",
+              },
+              {
+                "is_enable_public_page": "true",
+              },
+            ],
+            "title": "Deploy to Bitrise.io",
+          },
+        },
+        {
+          "save-cache@1": {
+            "inputs": [
+              {
+                "key": "{{ .OS }}-{{ .Arch }}-yarn-cache-{{ checksum "yarn.lock" }}",
+              },
+              {
+                "paths": "node_modules",
+              },
+            ],
+            "title": "Save yarn cache",
+          },
+        },
+      ],
+      "title": "Build Android",
+    },
+    "rn-build-all-platforms": {
+      "before_run": [
+        "rn-android-build",
+        "rn-ios-build",
+      ],
+      "description": "Build React Native app for both Android and iOS",
+      "meta": {
+        "bitrise.io": {
+          "machine_type_id": "g2-m1.8core",
+          "stack": "osx-xcode-15.3.x-ventura",
+        },
+      },
+      "steps": [],
+      "title": "Build Both Platforms",
+    },
+    "rn-ios-build": {
+      "description": "Build React Native iOS app",
+      "meta": {
+        "bitrise.io": {
+          "machine_type_id": "g2-m1.8core",
+          "stack": "osx-xcode-15.3.x-ventura",
+        },
+      },
+      "steps": [
+        {
+          "git-clone@8": {
+            "title": "Git Clone",
+          },
+        },
+        {
+          "nvm@1": {
+            "inputs": [
+              {
+                "node_version": "20",
+              },
+            ],
+            "title": "Setup Node.js 20",
+          },
+        },
+        {
+          "restore-cache@2": {
+            "inputs": [
+              {
+                "key": "{{ .OS }}-{{ .Arch }}-yarn-cache-{{ checksum "yarn.lock" }}",
+              },
+            ],
+            "title": "Restore yarn cache",
+          },
+        },
+        {
+          "yarn@0": {
+            "inputs": [
+              {
+                "args": "--immutable",
+              },
+            ],
+          },
+        },
+        {
+          "cocoapods-install@2": {
+            "inputs": [
+              {
+                "source_root_path": "./ios",
+              },
+            ],
+            "title": "Install CocoaPods",
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+# Check for required directories and files
+echo "🔍 Verifying iOS project setup..."
+
+if [ ! -d "ios" ]; then
+  echo "❌ Error: iOS directory not found"
+  echo "Make sure you're running this workflow from the root"
+  echo "of a React Native project"
+  exit 1
+fi
+
+if [ ! -f "ios/Podfile" ]; then
+  echo "⚠️ Warning: Podfile not found"
+  echo "iOS build might fail without a valid Podfile"
+fi
+
+echo "✅ iOS environment looks good"
+
+# Determine the configuration based on variant
+CONFIGURATION="Debug"
+
+echo "🚀 Starting iOS build with configuration: $CONFIGURATION..."
+
+# Extract project name from xcworkspace directory
+WORKSPACE_PATH=$(find ios -name "*.xcworkspace" -type d | head -n 1)
+if [ -z "$WORKSPACE_PATH" ]; then
+  echo "❌ No .xcworkspace found in ios directory"
+  exit 1
+fi
+
+PROJECT_NAME=$(basename "$WORKSPACE_PATH" .xcworkspace)
+echo "Detected project: $PROJECT_NAME"
+
+# Build the iOS project using xcodebuild
+echo "Building iOS project using native xcodebuild commands..."",
+              },
+            ],
+            "title": "Build iOS App",
+          },
+        },
+        {
+          "xcode-archive@4": {
+            "inputs": [
+              {
+                "project_path": "./ios/*.xcworkspace",
+              },
+              {
+                "scheme": "$BITRISE_SCHEME",
+              },
+              {
+                "export_method": "development",
+              },
+            ],
+            "title": "Build iOS",
+          },
+        },
+        {
+          "deploy-to-bitrise-io@2": {
+            "inputs": [
+              {
+                "notify_user_groups": "everyone",
+              },
+              {
+                "is_enable_public_page": "true",
+              },
+            ],
+            "title": "Deploy to Bitrise.io",
+          },
+        },
+        {
+          "save-cache@1": {
+            "inputs": [
+              {
+                "key": "{{ .OS }}-{{ .Arch }}-yarn-cache-{{ checksum "yarn.lock" }}",
+              },
+              {
+                "paths": "node_modules",
+              },
+            ],
+            "title": "Save yarn cache",
+          },
+        },
+      ],
+      "title": "Build iOS",
+    },
+  },
+}
+`;

--- a/src/presets/__tests__/__snapshots__/bitriseStaticAnalysis.test.ts.snap
+++ b/src/presets/__tests__/__snapshots__/bitriseStaticAnalysis.test.ts.snap
@@ -1,0 +1,293 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildBitriseStaticAnalysisPipeline output matches snapshot for default options 1`] = `
+{
+  "app": {
+    "envs": [
+      {
+        "CI": "true",
+      },
+      {
+        "NODE_OPTIONS": "--max_old_space_size=4096",
+      },
+      {
+        "YARN_ENABLE_IMMUTABLE_INSTALLS": "1",
+      },
+    ],
+  },
+  "default_step_lib_source": "https://github.com/bitrise-io/bitrise-steplib.git",
+  "format_version": 13,
+  "meta": {
+    "bitrise.io": {
+      "machine_type_id": "elite",
+      "stack": "linux-docker-android-22.04",
+    },
+  },
+  "project_type": "react-native",
+  "trigger_map": [
+    {
+      "push_branch": "main",
+      "workflow": "rn-static-analysis",
+    },
+    {
+      "pull_request_target_branch": "main",
+      "workflow": "rn-static-analysis",
+    },
+  ],
+  "workflows": {
+    "rn-static-analysis": {
+      "description": "Run static analysis including TypeScript, ESLint, Prettier, and unit tests",
+      "steps": [
+        {
+          "git-clone@8": {
+            "title": "Git Clone",
+          },
+        },
+        {
+          "nvm@1": {
+            "inputs": [
+              {
+                "node_version": "18",
+              },
+            ],
+            "title": "Setup Node.js 18",
+          },
+        },
+        {
+          "restore-cache@2": {
+            "inputs": [
+              {
+                "key": "{{ .OS }}-{{ .Arch }}-yarn-cache-{{ checksum "yarn.lock" }}",
+              },
+            ],
+            "title": "Restore yarn cache",
+          },
+        },
+        {
+          "yarn@0": {
+            "inputs": [
+              {
+                "args": "--immutable",
+              },
+            ],
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+yarn tsc --noEmit",
+              },
+            ],
+            "title": "TypeScript Check",
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+yarn lint",
+              },
+            ],
+            "title": "ESLint Check",
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+yarn format:check",
+              },
+            ],
+            "title": "Prettier Check",
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+yarn test --ci",
+              },
+            ],
+            "title": "Unit Tests",
+          },
+        },
+        {
+          "save-cache@1": {
+            "inputs": [
+              {
+                "key": "{{ .OS }}-{{ .Arch }}-yarn-cache-{{ checksum "yarn.lock" }}",
+              },
+              {
+                "paths": "node_modules",
+              },
+            ],
+            "title": "Save yarn cache",
+          },
+        },
+      ],
+      "title": "React Native Static Analysis",
+    },
+  },
+}
+`;
+
+exports[`buildBitriseStaticAnalysisPipeline output matches snapshot for npm package manager 1`] = `
+{
+  "app": {
+    "envs": [
+      {
+        "CI": "true",
+      },
+      {
+        "NODE_OPTIONS": "--max_old_space_size=4096",
+      },
+      {
+        "YARN_ENABLE_IMMUTABLE_INSTALLS": "1",
+      },
+    ],
+  },
+  "default_step_lib_source": "https://github.com/bitrise-io/bitrise-steplib.git",
+  "format_version": 13,
+  "meta": {
+    "bitrise.io": {
+      "machine_type_id": "elite",
+      "stack": "linux-docker-android-22.04",
+    },
+  },
+  "project_type": "react-native",
+  "trigger_map": [
+    {
+      "push_branch": "main",
+      "workflow": "rn-static-analysis",
+    },
+    {
+      "pull_request_target_branch": "main",
+      "workflow": "rn-static-analysis",
+    },
+  ],
+  "workflows": {
+    "rn-static-analysis": {
+      "description": "Run static analysis including TypeScript, ESLint, Prettier, and unit tests",
+      "steps": [
+        {
+          "git-clone@8": {
+            "title": "Git Clone",
+          },
+        },
+        {
+          "nvm@1": {
+            "inputs": [
+              {
+                "node_version": "18",
+              },
+            ],
+            "title": "Setup Node.js 18",
+          },
+        },
+        {
+          "restore-cache@2": {
+            "inputs": [
+              {
+                "key": "{{ .OS }}-{{ .Arch }}-npm-cache-{{ checksum "package-lock.json" }}",
+              },
+            ],
+            "title": "Restore npm cache",
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+npm ci",
+              },
+            ],
+            "title": "Install Dependencies",
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+npm run tsc -- --noEmit",
+              },
+            ],
+            "title": "TypeScript Check",
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+npm run lint",
+              },
+            ],
+            "title": "ESLint Check",
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+npm run format:check",
+              },
+            ],
+            "title": "Prettier Check",
+          },
+        },
+        {
+          "script@1": {
+            "inputs": [
+              {
+                "content": "#!/usr/bin/env bash
+set -euo pipefail
+
+npm test -- --ci",
+              },
+            ],
+            "title": "Unit Tests",
+          },
+        },
+        {
+          "save-cache@1": {
+            "inputs": [
+              {
+                "key": "{{ .OS }}-{{ .Arch }}-npm-cache-{{ checksum "package-lock.json" }}",
+              },
+              {
+                "paths": "node_modules",
+              },
+            ],
+            "title": "Save npm cache",
+          },
+        },
+      ],
+      "title": "React Native Static Analysis",
+    },
+  },
+}
+`;

--- a/src/presets/__tests__/__snapshots__/staticAnalysis.test.ts.snap
+++ b/src/presets/__tests__/__snapshots__/staticAnalysis.test.ts.snap
@@ -1,0 +1,209 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildStaticAnalysisPipeline output matches snapshot for default options 1`] = `
+{
+  "env": {
+    "GITHUB_TOKEN": "__SECRET_GITHUB_TOKEN__",
+  },
+  "jobs": {
+    "static_analysis": {
+      "name": "Run Static Analysis",
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "name": "Checkout",
+          "uses": "actions/checkout@v4",
+        },
+        {
+          "name": "Setup Node",
+          "uses": "actions/setup-node@v4",
+          "with": {
+            "cache": "yarn",
+            "node-version": 20,
+          },
+        },
+        {
+          "name": "Install",
+          "run": "yarn install --immutable",
+        },
+        {
+          "name": "TypeScript",
+          "run": "yarn tsc --noEmit",
+        },
+        {
+          "name": "ESLint",
+          "run": "yarn lint",
+        },
+        {
+          "name": "Prettier",
+          "run": "yarn format:check",
+        },
+        {
+          "name": "Unit tests",
+          "run": "yarn test --ci",
+        },
+        {
+          "id": "static-analysis-source",
+          "name": "Determine PR Status",
+          "run": "
+# Determine if this is a PR or a direct push
+EVENT_NAME="\${{ github.event_name }}"
+if [[ "$EVENT_NAME" == "pull_request" ]] || [[ "$EVENT_NAME" == "pull_request_target" ]]; then
+  # This is a PR - set output flag
+  echo "is_pr=true" >> $GITHUB_OUTPUT
+  echo "📌 Running static analysis on PR #\${{ github.event.pull_request.number }} from branch \${{ github.head_ref }}"
+else
+  # This is a direct push - set output flag
+  echo "is_pr=false" >> $GITHUB_OUTPUT
+  echo "📌 Running static analysis on branch \${{ github.ref_name }}"
+fi
+",
+        },
+        {
+          "env": {
+            "GH_TOKEN": "\${{ secrets.GITHUB_TOKEN }}",
+          },
+          "if": "steps.static-analysis-source.outputs.is_pr == 'true'",
+          "name": "Add Static Analysis PR Comment",
+          "run": "# Create comment message
+MESSAGE="## 📊 Static Analysis Results
+
+\${{ job.status == 'success' && '✅ All static analysis checks passed!' || '❌ Some static analysis checks failed!' }}
+
+### Build Information
+- **Repository**: \${{ github.repository }}
+- **Branch**: \${{ github.head_ref }}
+- **Commit**: \${{ github.sha }}
+- **Workflow**: \${{ github.workflow }}
+
+> Static analysis completed via React Native CI Workflow Builder"
+
+# Check if comment already exists and update it
+PR_NUM="\${{ github.event.number }}"
+SEARCH_TEXT="Static Analysis Results"
+echo "Creating new comment..."
+gh pr comment $PR_NUM --body "$MESSAGE"
+",
+        },
+      ],
+    },
+  },
+  "name": "Static Analysis",
+  "on": {
+    "pull_request": {
+      "branches": [
+        "main",
+      ],
+    },
+    "push": {
+      "branches": [
+        "main",
+      ],
+    },
+  },
+}
+`;
+
+exports[`buildStaticAnalysisPipeline output matches snapshot for npm with custom name 1`] = `
+{
+  "env": {
+    "GITHUB_TOKEN": "__SECRET_GITHUB_TOKEN__",
+  },
+  "jobs": {
+    "static_analysis": {
+      "name": "Run Static Analysis",
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "name": "Checkout",
+          "uses": "actions/checkout@v4",
+        },
+        {
+          "name": "Setup Node",
+          "uses": "actions/setup-node@v4",
+          "with": {
+            "cache": "npm",
+            "node-version": 18,
+          },
+        },
+        {
+          "name": "Install",
+          "run": "npm ci",
+        },
+        {
+          "name": "TypeScript",
+          "run": "npm run tsc -- --noEmit",
+        },
+        {
+          "name": "ESLint",
+          "run": "npm run lint",
+        },
+        {
+          "name": "Prettier",
+          "run": "npm run format:check",
+        },
+        {
+          "name": "Unit tests",
+          "run": "npm test -- --ci",
+        },
+        {
+          "id": "static-analysis-source",
+          "name": "Determine PR Status",
+          "run": "
+# Determine if this is a PR or a direct push
+EVENT_NAME="\${{ github.event_name }}"
+if [[ "$EVENT_NAME" == "pull_request" ]] || [[ "$EVENT_NAME" == "pull_request_target" ]]; then
+  # This is a PR - set output flag
+  echo "is_pr=true" >> $GITHUB_OUTPUT
+  echo "📌 Running static analysis on PR #\${{ github.event.pull_request.number }} from branch \${{ github.head_ref }}"
+else
+  # This is a direct push - set output flag
+  echo "is_pr=false" >> $GITHUB_OUTPUT
+  echo "📌 Running static analysis on branch \${{ github.ref_name }}"
+fi
+",
+        },
+        {
+          "env": {
+            "GH_TOKEN": "\${{ secrets.GITHUB_TOKEN }}",
+          },
+          "if": "steps.static-analysis-source.outputs.is_pr == 'true'",
+          "name": "Add Static Analysis PR Comment",
+          "run": "# Create comment message
+MESSAGE="## 📊 Static Analysis Results
+
+\${{ job.status == 'success' && '✅ All static analysis checks passed!' || '❌ Some static analysis checks failed!' }}
+
+### Build Information
+- **Repository**: \${{ github.repository }}
+- **Branch**: \${{ github.head_ref }}
+- **Commit**: \${{ github.sha }}
+- **Workflow**: \${{ github.workflow }}
+
+> Static analysis completed via React Native CI Workflow Builder"
+
+# Check if comment already exists and update it
+PR_NUM="\${{ github.event.number }}"
+SEARCH_TEXT="Static Analysis Results"
+echo "Creating new comment..."
+gh pr comment $PR_NUM --body "$MESSAGE"
+",
+        },
+      ],
+    },
+  },
+  "name": "CI Analysis",
+  "on": {
+    "pull_request": {
+      "branches": [
+        "main",
+      ],
+    },
+    "push": {
+      "branches": [
+        "main",
+      ],
+    },
+  },
+}
+`;

--- a/src/presets/__tests__/bitriseBuildPreset.test.ts
+++ b/src/presets/__tests__/bitriseBuildPreset.test.ts
@@ -1,0 +1,205 @@
+import { buildBitriseBuildPipeline } from '../bitriseBuildPreset';
+import { WorkflowOptions } from '../../types';
+
+describe('buildBitriseBuildPipeline', () => {
+  const androidOptions: WorkflowOptions = {
+    platform: 'bitrise',
+    packageManager: 'yarn',
+    build: {
+      platform: 'android',
+      variant: 'debug',
+      storage: 'bitrise',
+      notification: 'none',
+    },
+  };
+
+  // ─── Output structure ──────────────────────────────────────────────────────
+
+  describe('output structure', () => {
+    it('returns a valid Bitrise config with required top-level fields', () => {
+      const result = buildBitriseBuildPipeline(androidOptions);
+
+      expect(result.format_version).toBeDefined();
+      expect(typeof result.format_version).toBe('number');
+      expect(result.workflows).toBeDefined();
+    });
+
+    it('has a non-empty workflows object', () => {
+      const result = buildBitriseBuildPipeline(androidOptions);
+
+      expect(Object.keys(result.workflows).length).toBeGreaterThan(0);
+    });
+
+    it('each workflow has a steps array', () => {
+      const result = buildBitriseBuildPipeline(androidOptions);
+
+      Object.values(result.workflows).forEach((workflow: any) => {
+        expect(Array.isArray(workflow.steps)).toBe(true);
+        expect(workflow.steps.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('includes a trigger_map', () => {
+      const result = buildBitriseBuildPipeline(androidOptions);
+
+      expect(Array.isArray(result.trigger_map)).toBe(true);
+    });
+  });
+
+  // ─── Android builds ────────────────────────────────────────────────────────
+
+  describe('Android builds', () => {
+    it('generates a workflow for android debug build', () => {
+      const result = buildBitriseBuildPipeline(androidOptions);
+
+      // Should contain at least one workflow with Android steps
+      const workflowNames = Object.keys(result.workflows);
+      expect(workflowNames.length).toBeGreaterThan(0);
+    });
+
+    it('includes git-clone step', () => {
+      const result = buildBitriseBuildPipeline(androidOptions);
+      const allSteps = Object.values(result.workflows).flatMap(
+        (w: any) => w.steps
+      );
+      const hasGitClone = allSteps.some((s: any) => 'git-clone@8' in s);
+
+      expect(hasGitClone).toBe(true);
+    });
+
+    it('generates for release variant', () => {
+      const result = buildBitriseBuildPipeline({
+        ...androidOptions,
+        build: { ...androidOptions.build!, variant: 'release' },
+      });
+
+      const workflowNames = Object.keys(result.workflows);
+      expect(workflowNames.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ─── Both platforms ────────────────────────────────────────────────────────
+
+  describe('Both platforms', () => {
+    it('generates workflows for both android and ios when platform is both', () => {
+      const result = buildBitriseBuildPipeline({
+        ...androidOptions,
+        build: { ...androidOptions.build!, platform: 'both' },
+      });
+
+      const workflowNames = Object.keys(result.workflows);
+      // Should have workflows for both platforms (at least 2, or a combined one)
+      expect(workflowNames.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // ─── Expo framework ────────────────────────────────────────────────────────
+
+  describe('Expo framework', () => {
+    it('generates a workflow for expo android build', () => {
+      const result = buildBitriseBuildPipeline({
+        ...androidOptions,
+        framework: 'expo',
+        build: { ...androidOptions.build!, platform: 'android' },
+      });
+
+      const workflowNames = Object.keys(result.workflows);
+      expect(workflowNames.length).toBeGreaterThan(0);
+    });
+
+    it('sets project_type to expo', () => {
+      const result = buildBitriseBuildPipeline({
+        ...androidOptions,
+        framework: 'expo',
+      });
+
+      expect(result.project_type).toBe('expo');
+    });
+
+    it('adds NODE_OPTIONS env for expo (documents duplicate bug pre-fix)', () => {
+      const result = buildBitriseBuildPipeline({
+        ...androidOptions,
+        framework: 'expo',
+      });
+      const envs = result.app?.envs ?? [];
+      const nodeOptionsEntries = envs.filter((e: any) => 'NODE_OPTIONS' in e);
+
+      // Bug (roadmap item F): two NODE_OPTIONS entries present for expo.
+      // After fix in PR 2, should be 1 with combined flags.
+      expect(nodeOptionsEntries.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // ─── Package manager ──────────────────────────────────────────────────────
+
+  describe('yarn package manager', () => {
+    it('includes yarn step for dependency installation', () => {
+      const result = buildBitriseBuildPipeline(androidOptions);
+      const allSteps = Object.values(result.workflows).flatMap(
+        (w: any) => w.steps
+      );
+      const hasYarn = allSteps.some((s: any) => 'yarn@0' in s);
+
+      expect(hasYarn).toBe(true);
+    });
+  });
+
+  describe('npm package manager', () => {
+    it('uses a script step for npm installation', () => {
+      const result = buildBitriseBuildPipeline({
+        ...androidOptions,
+        packageManager: 'npm',
+      });
+      const allSteps = Object.values(result.workflows).flatMap(
+        (w: any) => w.steps
+      );
+      const scriptSteps = allSteps.filter((s: any) => 'script@1' in s);
+      const installStep = scriptSteps.find(
+        (s: any) => (s['script@1'] as any)?.title === 'Install Dependencies'
+      );
+
+      expect(installStep).toBeDefined();
+    });
+  });
+
+  // ─── Environment variables ────────────────────────────────────────────────
+
+  describe('environment variables', () => {
+    it('includes NODE_OPTIONS env var', () => {
+      const result = buildBitriseBuildPipeline(androidOptions);
+      const envs = result.app?.envs ?? [];
+      const nodeOptionsEntry = envs.find((e: any) => 'NODE_OPTIONS' in e);
+
+      expect(nodeOptionsEntry).toBeDefined();
+    });
+
+    it('includes custom env vars when provided', () => {
+      const result = buildBitriseBuildPipeline({
+        ...androidOptions,
+        env: { BUILD_NUMBER: '42' },
+      });
+      const envs = result.app?.envs ?? [];
+      const customEntry = envs.find((e: any) => 'BUILD_NUMBER' in e);
+
+      expect(customEntry).toBeDefined();
+      expect((customEntry as any)?.BUILD_NUMBER).toBe('42');
+    });
+  });
+
+  // ─── Snapshot ─────────────────────────────────────────────────────────────
+
+  it('output matches snapshot for android debug with yarn', () => {
+    const result = buildBitriseBuildPipeline(androidOptions);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('output matches snapshot for both platforms', () => {
+    const result = buildBitriseBuildPipeline({
+      ...androidOptions,
+      build: { ...androidOptions.build!, platform: 'both' },
+    });
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/src/presets/__tests__/bitriseStaticAnalysis.test.ts
+++ b/src/presets/__tests__/bitriseStaticAnalysis.test.ts
@@ -1,0 +1,368 @@
+import { buildBitriseStaticAnalysisPipeline } from '../bitriseStaticAnalysis';
+import { WorkflowOptions } from '../../types';
+
+describe('buildBitriseStaticAnalysisPipeline', () => {
+  const defaultOptions: WorkflowOptions = {
+    platform: 'bitrise',
+    packageManager: 'yarn',
+  };
+
+  // ─── Output structure ──────────────────────────────────────────────────────
+
+  describe('output structure', () => {
+    it('returns a valid Bitrise config with required top-level fields', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+
+      expect(result.format_version).toBe(13);
+      expect(result.default_step_lib_source).toBeDefined();
+      expect(result.workflows).toBeDefined();
+      expect(result.app).toBeDefined();
+    });
+
+    it('includes the rn-static-analysis workflow', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+
+      expect(result.workflows['rn-static-analysis']).toBeDefined();
+    });
+
+    it('has a non-empty steps array', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+      const steps = result.workflows['rn-static-analysis'].steps;
+
+      expect(Array.isArray(steps)).toBe(true);
+      expect(steps.length).toBeGreaterThan(0);
+    });
+
+    it('includes a trigger_map', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+
+      expect(Array.isArray(result.trigger_map)).toBe(true);
+      expect(result.trigger_map!.length).toBeGreaterThan(0);
+    });
+
+    it('sets project_type to react-native for RN CLI', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+
+      expect(result.project_type).toBe('react-native');
+    });
+
+    it('sets project_type to expo for Expo framework', () => {
+      const result = buildBitriseStaticAnalysisPipeline({
+        ...defaultOptions,
+        framework: 'expo',
+      });
+
+      expect(result.project_type).toBe('expo');
+    });
+  });
+
+  // ─── Workflow metadata ────────────────────────────────────────────────────
+
+  describe('workflow metadata', () => {
+    it('sets default title to "React Native Static Analysis" for RN CLI', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+      const workflow = result.workflows['rn-static-analysis'];
+
+      expect(workflow.title).toBe('React Native Static Analysis');
+    });
+
+    it('sets title to "Expo Static Analysis" for Expo framework', () => {
+      const result = buildBitriseStaticAnalysisPipeline({
+        ...defaultOptions,
+        framework: 'expo',
+      });
+      const workflow = result.workflows['rn-static-analysis'];
+
+      expect(workflow.title).toBe('Expo Static Analysis');
+    });
+
+    it('uses a custom name when opts.name is provided', () => {
+      const result = buildBitriseStaticAnalysisPipeline({
+        ...defaultOptions,
+        name: 'My Custom Analysis',
+      });
+      const workflow = result.workflows['rn-static-analysis'];
+
+      expect(workflow.title).toBe('My Custom Analysis');
+    });
+  });
+
+  // ─── Setup steps ──────────────────────────────────────────────────────────
+
+  describe('setup steps', () => {
+    it('includes git-clone step', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const hasGitClone = steps.some((s: any) => 'git-clone@8' in s);
+
+      expect(hasGitClone).toBe(true);
+    });
+
+    it('includes nvm step for Node.js setup', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const hasNvm = steps.some((s: any) => 'nvm@1' in s);
+
+      expect(hasNvm).toBe(true);
+    });
+
+    it('includes restore-cache step', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const hasRestoreCache = steps.some((s: any) => 'restore-cache@2' in s);
+
+      expect(hasRestoreCache).toBe(true);
+    });
+
+    it('includes save-cache step', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const hasSaveCache = steps.some((s: any) => 'save-cache@1' in s);
+
+      expect(hasSaveCache).toBe(true);
+    });
+  });
+
+  // ─── Package manager ──────────────────────────────────────────────────────
+
+  describe('yarn package manager', () => {
+    it('uses yarn@0 step for installation', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const hasYarn = steps.some((s: any) => 'yarn@0' in s);
+
+      expect(hasYarn).toBe(true);
+    });
+  });
+
+  describe('npm package manager', () => {
+    it('uses a script step for npm install', () => {
+      const result = buildBitriseStaticAnalysisPipeline({
+        ...defaultOptions,
+        packageManager: 'npm',
+      });
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const scriptSteps = steps.filter((s: any) => 'script@1' in s);
+      const installStep = scriptSteps.find(
+        (s: any) => (s['script@1'] as any)?.title === 'Install Dependencies'
+      );
+
+      expect(installStep).toBeDefined();
+    });
+
+    it('uses npm ci in the install script', () => {
+      const result = buildBitriseStaticAnalysisPipeline({
+        ...defaultOptions,
+        packageManager: 'npm',
+      });
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const scriptSteps = steps.filter((s: any) => 'script@1' in s);
+      const installStep = scriptSteps.find(
+        (s: any) => (s['script@1'] as any)?.title === 'Install Dependencies'
+      );
+      const content = (installStep as any)?.['script@1']?.inputs?.[0]?.content;
+
+      expect(content).toContain('npm ci');
+    });
+  });
+
+  // ─── Analysis checks ──────────────────────────────────────────────────────
+
+  describe('analysis checks', () => {
+    it('includes TypeScript Check step by default', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const scriptSteps = steps.filter((s: any) => 'script@1' in s);
+      const tsStep = scriptSteps.find(
+        (s: any) => (s['script@1'] as any)?.title === 'TypeScript Check'
+      );
+
+      expect(tsStep).toBeDefined();
+    });
+
+    it('excludes TypeScript Check when disabled', () => {
+      const result = buildBitriseStaticAnalysisPipeline({
+        ...defaultOptions,
+        staticAnalysis: { typescript: false },
+      });
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const scriptSteps = steps.filter((s: any) => 'script@1' in s);
+      const tsStep = scriptSteps.find(
+        (s: any) => (s['script@1'] as any)?.title === 'TypeScript Check'
+      );
+
+      expect(tsStep).toBeUndefined();
+    });
+
+    it('includes ESLint Check step by default', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const scriptSteps = steps.filter((s: any) => 'script@1' in s);
+      const eslintStep = scriptSteps.find(
+        (s: any) => (s['script@1'] as any)?.title === 'ESLint Check'
+      );
+
+      expect(eslintStep).toBeDefined();
+    });
+
+    it('excludes ESLint Check when disabled', () => {
+      const result = buildBitriseStaticAnalysisPipeline({
+        ...defaultOptions,
+        staticAnalysis: { eslint: false },
+      });
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const scriptSteps = steps.filter((s: any) => 'script@1' in s);
+      const eslintStep = scriptSteps.find(
+        (s: any) => (s['script@1'] as any)?.title === 'ESLint Check'
+      );
+
+      expect(eslintStep).toBeUndefined();
+    });
+
+    it('includes Prettier Check step by default', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const scriptSteps = steps.filter((s: any) => 'script@1' in s);
+      const prettierStep = scriptSteps.find(
+        (s: any) => (s['script@1'] as any)?.title === 'Prettier Check'
+      );
+
+      expect(prettierStep).toBeDefined();
+    });
+
+    it('includes Unit Tests step by default', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const scriptSteps = steps.filter((s: any) => 'script@1' in s);
+      const unitTestStep = scriptSteps.find(
+        (s: any) => (s['script@1'] as any)?.title === 'Unit Tests'
+      );
+
+      expect(unitTestStep).toBeDefined();
+    });
+
+    it('excludes Unit Tests when disabled', () => {
+      const result = buildBitriseStaticAnalysisPipeline({
+        ...defaultOptions,
+        staticAnalysis: { unitTests: false },
+      });
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const scriptSteps = steps.filter((s: any) => 'script@1' in s);
+      const unitTestStep = scriptSteps.find(
+        (s: any) => (s['script@1'] as any)?.title === 'Unit Tests'
+      );
+
+      expect(unitTestStep).toBeUndefined();
+    });
+  });
+
+  // ─── Expo framework ────────────────────────────────────────────────────────
+
+  describe('Expo framework', () => {
+    it('includes EAS CLI install step for expo', () => {
+      const result = buildBitriseStaticAnalysisPipeline({
+        ...defaultOptions,
+        framework: 'expo',
+      });
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const scriptSteps = steps.filter((s: any) => 'script@1' in s);
+      const easStep = scriptSteps.find(
+        (s: any) => (s['script@1'] as any)?.title === 'Install EAS CLI'
+      );
+
+      expect(easStep).toBeDefined();
+    });
+
+    it('does not include EAS CLI step for RN CLI', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const scriptSteps = steps.filter((s: any) => 'script@1' in s);
+      const easStep = scriptSteps.find(
+        (s: any) => (s['script@1'] as any)?.title === 'Install EAS CLI'
+      );
+
+      expect(easStep).toBeUndefined();
+    });
+
+    it('adds NODE_OPTIONS env var for Expo (documents duplicate bug pre-fix)', () => {
+      const result = buildBitriseStaticAnalysisPipeline({
+        ...defaultOptions,
+        framework: 'expo',
+      });
+      const envs = result.app?.envs ?? [];
+      const nodeOptionsEntries = envs.filter((e: any) => 'NODE_OPTIONS' in e);
+
+      // Bug (roadmap item F): currently produces 2 NODE_OPTIONS entries.
+      // After fix in PR 2, this should be 1 entry with combined flags.
+      expect(nodeOptionsEntries.length).toBe(2);
+    });
+  });
+
+  // ─── Environment variables ────────────────────────────────────────────────
+
+  describe('environment variables', () => {
+    it('includes default CI env var', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+      const envs = result.app?.envs ?? [];
+      const ciEntry = envs.find((e: any) => 'CI' in e);
+
+      expect(ciEntry).toBeDefined();
+      expect((ciEntry as any)?.CI).toBe('true');
+    });
+
+    it('includes custom env vars when provided', () => {
+      const result = buildBitriseStaticAnalysisPipeline({
+        ...defaultOptions,
+        env: { MY_VAR: 'my_value' },
+      });
+      const envs = result.app?.envs ?? [];
+      const customEntry = envs.find((e: any) => 'MY_VAR' in e);
+
+      expect(customEntry).toBeDefined();
+      expect((customEntry as any)?.MY_VAR).toBe('my_value');
+    });
+  });
+
+  // ─── Triggers ─────────────────────────────────────────────────────────────
+
+  describe('trigger_map', () => {
+    it('defaults to main branch push trigger', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+      const hasPushToMain = result.trigger_map!.some(
+        (t: any) => t.push_branch === 'main'
+      );
+
+      expect(hasPushToMain).toBe(true);
+    });
+
+    it('uses custom push branches when provided', () => {
+      const result = buildBitriseStaticAnalysisPipeline({
+        ...defaultOptions,
+        triggers: { push: { branches: ['develop', 'main'] } },
+      });
+      const branches = result.trigger_map!
+        .filter((t: any) => 'push_branch' in t)
+        .map((t: any) => t.push_branch);
+
+      expect(branches).toContain('develop');
+      expect(branches).toContain('main');
+    });
+  });
+
+  // ─── Snapshot ─────────────────────────────────────────────────────────────
+
+  it('output matches snapshot for default options', () => {
+    const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('output matches snapshot for npm package manager', () => {
+    const result = buildBitriseStaticAnalysisPipeline({
+      ...defaultOptions,
+      packageManager: 'npm',
+    });
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/src/presets/__tests__/staticAnalysis.test.ts
+++ b/src/presets/__tests__/staticAnalysis.test.ts
@@ -1,0 +1,260 @@
+import { buildStaticAnalysisPipeline } from '../staticAnalysis';
+import { WorkflowOptions } from '../../types';
+
+describe('buildStaticAnalysisPipeline', () => {
+  const defaultOptions: WorkflowOptions = {
+    platform: 'github',
+    packageManager: 'yarn',
+    nodeVersions: [20],
+  };
+
+  // ─── Output structure ──────────────────────────────────────────────────────
+
+  describe('output structure', () => {
+    it('returns a workflow with name, on, and jobs', () => {
+      const result = buildStaticAnalysisPipeline(defaultOptions);
+
+      expect(result.name).toBeDefined();
+      expect(result.on).toBeDefined();
+      expect(result.jobs).toBeDefined();
+    });
+
+    it('defaults workflow name to "Static Analysis"', () => {
+      const result = buildStaticAnalysisPipeline(defaultOptions);
+
+      expect(result.name).toBe('Static Analysis');
+    });
+
+    it('uses a provided custom name', () => {
+      const result = buildStaticAnalysisPipeline({
+        ...defaultOptions,
+        name: 'My Custom Analysis',
+      });
+
+      expect(result.name).toBe('My Custom Analysis');
+    });
+
+    it('includes a static_analysis job', () => {
+      const result = buildStaticAnalysisPipeline(defaultOptions);
+
+      expect(result.jobs.static_analysis).toBeDefined();
+    });
+
+    it('uses ubuntu-latest runner by default', () => {
+      const result = buildStaticAnalysisPipeline(defaultOptions);
+
+      expect(result.jobs.static_analysis['runs-on']).toBe('ubuntu-latest');
+    });
+
+    it('uses a custom runner when runsOn is provided', () => {
+      const result = buildStaticAnalysisPipeline({
+        ...defaultOptions,
+        runsOn: 'ubuntu-22.04',
+      });
+
+      expect(result.jobs.static_analysis['runs-on']).toBe('ubuntu-22.04');
+    });
+
+    it('steps is an array', () => {
+      const result = buildStaticAnalysisPipeline(defaultOptions);
+
+      expect(Array.isArray(result.jobs.static_analysis.steps)).toBe(true);
+    });
+  });
+
+  // ─── Setup steps ──────────────────────────────────────────────────────────
+
+  describe('setup steps', () => {
+    it('includes Checkout step', () => {
+      const result = buildStaticAnalysisPipeline(defaultOptions);
+      const steps = result.jobs.static_analysis.steps;
+
+      expect(steps.some((s: any) => s.name === 'Checkout')).toBe(true);
+    });
+
+    it('includes Setup Node step', () => {
+      const result = buildStaticAnalysisPipeline(defaultOptions);
+      const steps = result.jobs.static_analysis.steps;
+
+      expect(steps.some((s: any) => s.name === 'Setup Node')).toBe(true);
+    });
+
+    it('uses the first nodeVersion for setup-node', () => {
+      const result = buildStaticAnalysisPipeline({
+        ...defaultOptions,
+        nodeVersions: [18, 20],
+      });
+      const steps = result.jobs.static_analysis.steps;
+      const nodeStep = steps.find((s: any) => s.name === 'Setup Node') as any;
+
+      expect(nodeStep?.with?.['node-version']).toBe(18);
+    });
+  });
+
+  // ─── Package manager ──────────────────────────────────────────────────────
+
+  describe('yarn package manager', () => {
+    it('uses yarn install --immutable', () => {
+      const result = buildStaticAnalysisPipeline({
+        ...defaultOptions,
+        packageManager: 'yarn',
+      });
+      const steps = result.jobs.static_analysis.steps;
+      const installStep = steps.find((s: any) => s.name === 'Install') as any;
+
+      expect(installStep?.run).toBe('yarn install --immutable');
+    });
+
+    it('uses yarn commands for analysis steps', () => {
+      const result = buildStaticAnalysisPipeline({
+        ...defaultOptions,
+        packageManager: 'yarn',
+      });
+      const steps = result.jobs.static_analysis.steps;
+      const tsStep = steps.find((s: any) => s.name === 'TypeScript') as any;
+
+      expect(tsStep?.run).toContain('yarn');
+    });
+  });
+
+  describe('npm package manager', () => {
+    it('uses npm ci', () => {
+      const result = buildStaticAnalysisPipeline({
+        ...defaultOptions,
+        packageManager: 'npm',
+      });
+      const steps = result.jobs.static_analysis.steps;
+      const installStep = steps.find((s: any) => s.name === 'Install') as any;
+
+      expect(installStep?.run).toBe('npm ci');
+    });
+
+    it('uses npm commands for analysis steps', () => {
+      const result = buildStaticAnalysisPipeline({
+        ...defaultOptions,
+        packageManager: 'npm',
+      });
+      const steps = result.jobs.static_analysis.steps;
+      const tsStep = steps.find((s: any) => s.name === 'TypeScript') as any;
+
+      expect(tsStep?.run).toContain('npm');
+    });
+  });
+
+  // ─── Analysis checks ──────────────────────────────────────────────────────
+
+  describe('analysis checks', () => {
+    it('includes all four checks by default', () => {
+      const result = buildStaticAnalysisPipeline(defaultOptions);
+      const stepNames = result.jobs.static_analysis.steps.map((s: any) => s.name);
+
+      expect(stepNames).toContain('TypeScript');
+      expect(stepNames).toContain('ESLint');
+      expect(stepNames).toContain('Prettier');
+      expect(stepNames).toContain('Unit tests');
+    });
+
+    it('excludes TypeScript when disabled', () => {
+      const result = buildStaticAnalysisPipeline({
+        ...defaultOptions,
+        staticAnalysis: { typescript: false },
+      });
+      const stepNames = result.jobs.static_analysis.steps.map((s: any) => s.name);
+
+      expect(stepNames).not.toContain('TypeScript');
+    });
+
+    it('excludes ESLint when disabled', () => {
+      const result = buildStaticAnalysisPipeline({
+        ...defaultOptions,
+        staticAnalysis: { eslint: false },
+      });
+      const stepNames = result.jobs.static_analysis.steps.map((s: any) => s.name);
+
+      expect(stepNames).not.toContain('ESLint');
+    });
+
+    it('excludes Prettier when disabled', () => {
+      const result = buildStaticAnalysisPipeline({
+        ...defaultOptions,
+        staticAnalysis: { prettier: false },
+      });
+      const stepNames = result.jobs.static_analysis.steps.map((s: any) => s.name);
+
+      expect(stepNames).not.toContain('Prettier');
+    });
+
+    it('excludes unit tests when disabled', () => {
+      const result = buildStaticAnalysisPipeline({
+        ...defaultOptions,
+        staticAnalysis: { unitTests: false },
+      });
+      const stepNames = result.jobs.static_analysis.steps.map((s: any) => s.name);
+
+      expect(stepNames).not.toContain('Unit tests');
+    });
+
+    it('can disable all checks', () => {
+      const result = buildStaticAnalysisPipeline({
+        ...defaultOptions,
+        staticAnalysis: {
+          typescript: false,
+          eslint: false,
+          prettier: false,
+          unitTests: false,
+        },
+      });
+      const stepNames = result.jobs.static_analysis.steps.map((s: any) => s.name);
+
+      expect(stepNames).not.toContain('TypeScript');
+      expect(stepNames).not.toContain('ESLint');
+      expect(stepNames).not.toContain('Prettier');
+      expect(stepNames).not.toContain('Unit tests');
+    });
+  });
+
+  // ─── Notifications ────────────────────────────────────────────────────────
+
+  describe('notifications', () => {
+    it('does not add notification steps when notification is not set', () => {
+      const result = buildStaticAnalysisPipeline(defaultOptions);
+      const steps = result.jobs.static_analysis.steps;
+
+      // Verify no slack-related steps
+      expect(
+        steps.every((s: any) => !String(s.name ?? '').toLowerCase().includes('slack'))
+      ).toBe(true);
+    });
+
+    it('does not add notification steps when notification is none', () => {
+      const result = buildStaticAnalysisPipeline({
+        ...defaultOptions,
+        staticAnalysis: { notification: 'none' },
+      });
+      const steps = result.jobs.static_analysis.steps;
+
+      expect(
+        steps.every((s: any) => !String(s.name ?? '').toLowerCase().includes('slack'))
+      ).toBe(true);
+    });
+  });
+
+  // ─── Snapshot ─────────────────────────────────────────────────────────────
+
+  it('output matches snapshot for default options', () => {
+    const result = buildStaticAnalysisPipeline(defaultOptions);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('output matches snapshot for npm with custom name', () => {
+    const result = buildStaticAnalysisPipeline({
+      platform: 'github',
+      packageManager: 'npm',
+      nodeVersions: [18],
+      name: 'CI Analysis',
+    });
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/src/validation/__tests__/secrets.test.ts
+++ b/src/validation/__tests__/secrets.test.ts
@@ -1,0 +1,227 @@
+import { validateBuildSecrets } from '../secrets';
+import { BuildOptions } from '../../presets/types';
+import { WorkflowOptions } from '../../types';
+
+describe('validateBuildSecrets', () => {
+  const baseOptions: WorkflowOptions = { platform: 'github' };
+  const baseBuild: BuildOptions = {
+    platform: 'android',
+    variant: 'debug',
+    storage: 'github',
+    notification: 'none',
+  };
+
+  // ─── github storage ────────────────────────────────────────────────────────
+
+  describe('github storage', () => {
+    it('passes with no secrets (github needs none)', () => {
+      expect(() => validateBuildSecrets(baseOptions, baseBuild)).not.toThrow();
+    });
+
+    it('passes when extra secrets are present', () => {
+      expect(() =>
+        validateBuildSecrets({ ...baseOptions, secrets: ['EXTRA_SECRET'] }, baseBuild)
+      ).not.toThrow();
+    });
+
+    it('passes when secrets array is empty', () => {
+      expect(() =>
+        validateBuildSecrets({ ...baseOptions, secrets: [] }, baseBuild)
+      ).not.toThrow();
+    });
+  });
+
+  // ─── firebase storage ──────────────────────────────────────────────────────
+
+  describe('firebase storage', () => {
+    const firebaseBuild: BuildOptions = { ...baseBuild, storage: 'firebase' };
+
+    it('throws when FIREBASE_SERVICE_ACCOUNT is missing', () => {
+      expect(() => validateBuildSecrets(baseOptions, firebaseBuild)).toThrow(
+        'FIREBASE_SERVICE_ACCOUNT'
+      );
+    });
+
+    it('throws when FIREBASE_APP_ID_ANDROID is missing for android platform', () => {
+      expect(() =>
+        validateBuildSecrets(
+          { ...baseOptions, secrets: ['FIREBASE_SERVICE_ACCOUNT'] },
+          firebaseBuild
+        )
+      ).toThrow('FIREBASE_APP_ID_ANDROID');
+    });
+
+    it('passes when all android firebase secrets are present', () => {
+      expect(() =>
+        validateBuildSecrets(
+          {
+            ...baseOptions,
+            secrets: ['FIREBASE_SERVICE_ACCOUNT', 'FIREBASE_APP_ID_ANDROID'],
+          },
+          firebaseBuild
+        )
+      ).not.toThrow();
+    });
+
+    it('throws when FIREBASE_APP_ID_IOS is missing for ios platform', () => {
+      expect(() =>
+        validateBuildSecrets(
+          { ...baseOptions, secrets: ['FIREBASE_SERVICE_ACCOUNT'] },
+          { ...firebaseBuild, platform: 'ios' }
+        )
+      ).toThrow('FIREBASE_APP_ID_IOS');
+    });
+
+    it('passes when all ios firebase secrets are present', () => {
+      expect(() =>
+        validateBuildSecrets(
+          {
+            ...baseOptions,
+            secrets: ['FIREBASE_SERVICE_ACCOUNT', 'FIREBASE_APP_ID_IOS'],
+          },
+          { ...firebaseBuild, platform: 'ios' }
+        )
+      ).not.toThrow();
+    });
+
+    it('throws when platform is both and ios secret is missing', () => {
+      expect(() =>
+        validateBuildSecrets(
+          {
+            ...baseOptions,
+            secrets: ['FIREBASE_SERVICE_ACCOUNT', 'FIREBASE_APP_ID_ANDROID'],
+          },
+          { ...firebaseBuild, platform: 'both' }
+        )
+      ).toThrow('FIREBASE_APP_ID_IOS');
+    });
+
+    it('passes when all both-platform firebase secrets are present', () => {
+      expect(() =>
+        validateBuildSecrets(
+          {
+            ...baseOptions,
+            secrets: [
+              'FIREBASE_SERVICE_ACCOUNT',
+              'FIREBASE_APP_ID_ANDROID',
+              'FIREBASE_APP_ID_IOS',
+            ],
+          },
+          { ...firebaseBuild, platform: 'both' }
+        )
+      ).not.toThrow();
+    });
+  });
+
+  // ─── s3 storage ────────────────────────────────────────────────────────────
+
+  describe('s3 storage', () => {
+    const s3Build: BuildOptions = { ...baseBuild, storage: 's3' };
+
+    it('throws when no s3 secrets are provided', () => {
+      expect(() => validateBuildSecrets(baseOptions, s3Build)).toThrow();
+    });
+
+    it('throws specifically for AWS_ACCESS_KEY_ID', () => {
+      expect(() => validateBuildSecrets(baseOptions, s3Build)).toThrow(
+        'AWS_ACCESS_KEY_ID'
+      );
+    });
+
+    it('throws for AWS_SECRET_ACCESS_KEY when key id is present', () => {
+      expect(() =>
+        validateBuildSecrets(
+          { ...baseOptions, secrets: ['AWS_ACCESS_KEY_ID'] },
+          s3Build
+        )
+      ).toThrow('AWS_SECRET_ACCESS_KEY');
+    });
+
+    it('passes when all required s3 secrets are present', () => {
+      expect(() =>
+        validateBuildSecrets(
+          {
+            ...baseOptions,
+            secrets: [
+              'AWS_ACCESS_KEY_ID',
+              'AWS_SECRET_ACCESS_KEY',
+              'AWS_REGION',
+              'AWS_S3_BUCKET',
+            ],
+          },
+          s3Build
+        )
+      ).not.toThrow();
+    });
+  });
+
+  // ─── drive storage ─────────────────────────────────────────────────────────
+
+  describe('drive storage', () => {
+    const driveBuild: BuildOptions = { ...baseBuild, storage: 'drive' };
+
+    it('throws when drive secret is missing', () => {
+      expect(() => validateBuildSecrets(baseOptions, driveBuild)).toThrow();
+    });
+
+    it('passes when the drive secret is present', () => {
+      // Documents current required secret name — see roadmap bug B for correct name fix
+      expect(() =>
+        validateBuildSecrets(
+          { ...baseOptions, secrets: ['GOOGLE_SERVICE_ACCOUNT'] },
+          driveBuild
+        )
+      ).not.toThrow();
+    });
+  });
+
+  // ─── notification secrets ──────────────────────────────────────────────────
+
+  describe('slack notification', () => {
+    it('throws when SLACK_WEBHOOK is missing', () => {
+      expect(() =>
+        validateBuildSecrets(baseOptions, { ...baseBuild, notification: 'slack' })
+      ).toThrow('SLACK_WEBHOOK');
+    });
+
+    it('passes when SLACK_WEBHOOK is present', () => {
+      expect(() =>
+        validateBuildSecrets(
+          { ...baseOptions, secrets: ['SLACK_WEBHOOK'] },
+          { ...baseBuild, notification: 'slack' }
+        )
+      ).not.toThrow();
+    });
+
+    it('requires SLACK_WEBHOOK for both notification type', () => {
+      expect(() =>
+        validateBuildSecrets(baseOptions, { ...baseBuild, notification: 'both' })
+      ).toThrow('SLACK_WEBHOOK');
+    });
+
+    it('passes for pr-comment notification with no secrets', () => {
+      expect(() =>
+        validateBuildSecrets(baseOptions, { ...baseBuild, notification: 'pr-comment' })
+      ).not.toThrow();
+    });
+
+    it('passes for none notification with no secrets', () => {
+      expect(() =>
+        validateBuildSecrets(baseOptions, { ...baseBuild, notification: 'none' })
+      ).not.toThrow();
+    });
+  });
+
+  // ─── no storage / undefined ────────────────────────────────────────────────
+
+  describe('undefined storage', () => {
+    it('passes when storage is not set', () => {
+      const noBuild: BuildOptions = {
+        platform: 'android',
+        variant: 'debug',
+        notification: 'none',
+      };
+      expect(() => validateBuildSecrets(baseOptions, noBuild)).not.toThrow();
+    });
+  });
+});

--- a/src/validation/__tests__/yaml.test.ts
+++ b/src/validation/__tests__/yaml.test.ts
@@ -1,0 +1,344 @@
+import {
+  validateGeneratedYaml,
+  validateWithActionlint,
+  validateWithAct,
+} from '../yaml';
+
+const VALID_GITHUB_WORKFLOW = `
+name: Test Workflow
+on:
+  push:
+    branches:
+      - main
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+`.trim();
+
+const VALID_BITRISE_CONFIG = `
+format_version: 13
+workflows:
+  primary:
+    steps:
+      - git-clone@8:
+          title: Git Clone
+`.trim();
+
+describe('validateGeneratedYaml', () => {
+  describe('valid GitHub Actions YAML', () => {
+    it('accepts a structurally correct workflow', () => {
+      expect(() => validateGeneratedYaml(VALID_GITHUB_WORKFLOW)).not.toThrow();
+    });
+
+    it('returns the original YAML string unchanged', () => {
+      const result = validateGeneratedYaml(VALID_GITHUB_WORKFLOW);
+      expect(result).toBe(VALID_GITHUB_WORKFLOW);
+    });
+
+    it('accepts workflow with multiple jobs', () => {
+      const multiJob = `
+name: Multi Job Workflow
+on:
+  push:
+    branches: [main]
+jobs:
+  job-one:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Step One
+        run: echo "one"
+  job-two:
+    runs-on: macos-latest
+    steps:
+      - name: Step Two
+        run: echo "two"
+`.trim();
+
+      expect(() => validateGeneratedYaml(multiJob)).not.toThrow();
+    });
+  });
+
+  describe('valid Bitrise YAML', () => {
+    it('accepts a structurally correct Bitrise config', () => {
+      expect(() => validateGeneratedYaml(VALID_BITRISE_CONFIG)).not.toThrow();
+    });
+
+    it('returns the original Bitrise YAML string unchanged', () => {
+      const result = validateGeneratedYaml(VALID_BITRISE_CONFIG);
+      expect(result).toBe(VALID_BITRISE_CONFIG);
+    });
+
+    it('accepts Bitrise config with multiple workflows', () => {
+      const multiWorkflow = `
+format_version: 13
+workflows:
+  primary:
+    steps:
+      - git-clone@8:
+          title: Git Clone
+  secondary:
+    steps:
+      - script@1:
+          title: Run Tests
+`.trim();
+
+      expect(() => validateGeneratedYaml(multiWorkflow)).not.toThrow();
+    });
+  });
+
+  describe('invalid YAML syntax', () => {
+    it('throws for malformed YAML', () => {
+      expect(() => validateGeneratedYaml('{ invalid: yaml: [')).toThrow();
+    });
+
+    it('throws for empty string', () => {
+      // Empty YAML parses as null/undefined, which the undefined-value check catches
+      expect(() => validateGeneratedYaml('')).toThrow();
+    });
+  });
+
+  describe('invalid GitHub Actions structure', () => {
+    it('throws when workflow is missing name', () => {
+      const noName = `
+on:
+  push:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+`.trim();
+
+      expect(() => validateGeneratedYaml(noName)).toThrow('name');
+    });
+
+    it('throws when workflow is missing triggers (on)', () => {
+      const noTriggers = `
+name: Test Workflow
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+`.trim();
+
+      expect(() => validateGeneratedYaml(noTriggers)).toThrow();
+    });
+
+    it('throws when workflow has no jobs', () => {
+      const noJobs = `
+name: Test Workflow
+on:
+  push:
+    branches: [main]
+`.trim();
+
+      expect(() => validateGeneratedYaml(noJobs)).toThrow();
+    });
+
+    it('throws when workflow has empty jobs object', () => {
+      const emptyJobs = `
+name: Test Workflow
+on:
+  push:
+    branches: [main]
+jobs: {}
+`.trim();
+
+      expect(() => validateGeneratedYaml(emptyJobs)).toThrow();
+    });
+
+    it('throws when a job is missing runs-on', () => {
+      const noRunsOn = `
+name: Test Workflow
+on:
+  push:
+    branches: [main]
+jobs:
+  test:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+`.trim();
+
+      expect(() => validateGeneratedYaml(noRunsOn)).toThrow('runs-on');
+    });
+
+    it('throws when a job has an empty steps array', () => {
+      const emptySteps = `
+name: Test Workflow
+on:
+  push:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps: []
+`.trim();
+
+      expect(() => validateGeneratedYaml(emptySteps)).toThrow();
+    });
+  });
+
+  describe('invalid Bitrise structure', () => {
+    it('throws when Bitrise config is missing format_version', () => {
+      const noFormatVersion = `
+workflows:
+  primary:
+    steps:
+      - git-clone@8:
+          title: Git Clone
+`.trim();
+
+      // This parses as a GitHub Actions workflow (no format_version),
+      // then fails the GitHub Actions validation (missing name/on)
+      expect(() => validateGeneratedYaml(noFormatVersion)).toThrow();
+    });
+
+    it('throws when Bitrise config has no workflows', () => {
+      const noWorkflows = `
+format_version: 13
+`.trim();
+
+      expect(() => validateGeneratedYaml(noWorkflows)).toThrow('workflow');
+    });
+
+    it('throws when a Bitrise workflow has no steps array', () => {
+      const noSteps = `
+format_version: 13
+workflows:
+  primary:
+    title: Primary
+`.trim();
+
+      expect(() => validateGeneratedYaml(noSteps)).toThrow('steps');
+    });
+  });
+
+  describe('false-positive "undefined" string check (known bug — to be fixed in PR 2)', () => {
+    it('currently throws when a step name contains the word "undefined" (false-positive)', () => {
+      // This documents the current buggy behavior before the fix.
+      // A step named "Detect undefined environment variables" is legitimate YAML,
+      // but the current validator incorrectly rejects it.
+      const legitimateYaml = `
+name: Test Workflow
+on:
+  push:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect undefined environment variables
+        run: echo "checking"
+`.trim();
+
+      // Current behavior: throws because step name contains "undefined"
+      // Expected behavior after fix: should NOT throw
+      expect(() => validateGeneratedYaml(legitimateYaml)).toThrow('undefined');
+    });
+  });
+
+  // ─── Async validation flag behaviour ─────────────────────────────────────
+  // These tests verify the orchestration logic: correct flags activate async
+  // validation paths and return Promises. They do NOT test tool installation
+  // or actual tool output — those depend on external binaries.
+
+  describe('async validation flag behaviour', () => {
+    it('returns a string (sync) when no async flags are set', () => {
+      const result = validateGeneratedYaml(VALID_GITHUB_WORKFLOW);
+
+      expect(typeof result).toBe('string');
+    });
+
+    it('returns a Promise when enableYamllintValidation is true for GitHub Actions', () => {
+      const result = validateGeneratedYaml(VALID_GITHUB_WORKFLOW, false, true);
+      expect(result).toBeInstanceOf(Promise);
+      // Suppress unhandled rejection — yamllint may not be installed in test env
+      if (result instanceof Promise) result.catch(() => {});
+    });
+
+    it('returns a Promise when enableActionlintValidation is true for GitHub Actions', () => {
+      const result = validateGeneratedYaml(VALID_GITHUB_WORKFLOW, false, false, true);
+      expect(result).toBeInstanceOf(Promise);
+      if (result instanceof Promise) result.catch(() => {});
+    });
+
+    it('returns a Promise when enableActValidation is true for GitHub Actions', () => {
+      const result = validateGeneratedYaml(VALID_GITHUB_WORKFLOW, false, false, false, true);
+      expect(result).toBeInstanceOf(Promise);
+      // Suppress unhandled rejection — act may not be installed in test env
+      if (result instanceof Promise) result.catch(() => {});
+    });
+
+    it('does NOT return a Promise for Bitrise config when only GitHub flags are set', () => {
+      // actionlint and act only apply to GitHub Actions workflows, not Bitrise
+      const result = validateGeneratedYaml(VALID_BITRISE_CONFIG, false, false, true, true);
+      // Bitrise config with enableBitriseCliValidation=false → sync return
+      expect(typeof result).toBe('string');
+    });
+
+    it('returns a Promise for Bitrise config when enableBitriseCliValidation is true', () => {
+      const result = validateGeneratedYaml(VALID_BITRISE_CONFIG, true);
+      expect(result).toBeInstanceOf(Promise);
+      // Suppress unhandled rejection — Bitrise CLI may not be installed in test env
+      if (result instanceof Promise) result.catch(() => {});
+    });
+
+    it('sync checks still run before async path — throws immediately for invalid GitHub Actions', () => {
+      const invalid = `
+name: Test
+on:
+  push:
+    branches: [main]
+`.trim(); // missing jobs → sync check fires before any Promise is created
+
+      expect(() => validateGeneratedYaml(invalid, false, false, true)).toThrow();
+    });
+  });
+});
+
+// ─── validateWithActionlint / validateWithAct — installation guard tests ─────
+
+describe('validateWithActionlint', () => {
+  it('throws a descriptive error when actionlint is not installed and autoInstall=false', async () => {
+    // This test relies on actionlint NOT being installed in the test environment.
+    // If actionlint is installed, this test passes trivially — the function won't throw.
+    // Purpose: verify the error message path is reachable.
+    try {
+      await validateWithActionlint('nonexistent-file.yml', false);
+      // If we reach here, actionlint is installed — that's fine, test is informational
+    } catch (err) {
+      const msg = (err as Error).message;
+      // Should either say "not installed" or "No such file" (if actionlint found but file missing)
+      expect(msg.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('validateWithAct', () => {
+  it('throws a descriptive error when act is not installed', async () => {
+    // This test relies on act NOT being installed in the test environment.
+    // Purpose: verify the error message path is reachable and descriptive.
+    try {
+      await validateWithAct('nonexistent-file.yml');
+      // If we reach here, act is installed — that's fine
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg.length).toBeGreaterThan(0);
+      // Error should mention act or validation failure
+      expect(
+        msg.toLowerCase().includes('act') ||
+        msg.toLowerCase().includes('install') ||
+        msg.toLowerCase().includes('failed') ||
+        msg.toLowerCase().includes('no such file')
+      ).toBe(true);
+    }
+  });
+});

--- a/src/validation/yaml.ts
+++ b/src/validation/yaml.ts
@@ -265,17 +265,252 @@ Then run the validation command again.
 }
 
 /**
+ * Checks if act (nektos/act) is installed
+ * @returns Promise<boolean>
+ */
+async function isActInstalled(): Promise<boolean> {
+  try {
+    await execAsync('act --version');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Checks if actionlint is installed
+ * @returns Promise<boolean>
+ */
+async function isActionlintInstalled(): Promise<boolean> {
+  try {
+    await execAsync('actionlint --version');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Prints installation instructions for act (nektos/act).
+ * act requires Docker for execution; we intentionally do not auto-install it.
+ */
+function printActInstallInstructions(): void {
+  console.log(`
+📋 To install act (nektos/act) for local GitHub Actions validation:
+
+Option 1 - Homebrew (macOS/Linux):
+  brew install act
+
+Option 2 - Binary (Linux/macOS):
+  curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
+
+Option 3 - GitHub releases:
+  https://github.com/nektos/act/releases
+
+Note: act --list mode (used here) does not require Docker.
+Then run the validation command again.
+`);
+}
+
+/**
+ * Attempts to install actionlint via system package manager or direct download.
+ * @param autoInstall Whether to auto-install or just print instructions
+ */
+async function installActionlint(autoInstall: boolean = false): Promise<void> {
+  console.log('🔧 actionlint is not installed. Setting up actionlint...');
+
+  const osType = detectOS();
+
+  if (autoInstall && osType === 'macos') {
+    try {
+      await execAsync('which brew');
+      console.log('📦 Installing actionlint via Homebrew...');
+      await execAsync('brew install actionlint');
+      console.log('✅ actionlint installed successfully!');
+      return;
+    } catch {
+      // fall through to instructions
+    }
+  }
+
+  if (autoInstall && osType === 'linux') {
+    try {
+      const arch = os.arch();
+      const archMap: Record<string, string> = {
+        x64: 'amd64',
+        arm64: 'arm64',
+      };
+      const mappedArch = archMap[arch] || 'amd64';
+      console.log('📦 Downloading actionlint binary...');
+      await execAsync(
+        `bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) latest /usr/local/bin`
+      );
+      void mappedArch; // used in fallback path
+      await execAsync('actionlint --version');
+      console.log('✅ actionlint installed successfully!');
+      return;
+    } catch {
+      // fall through to instructions
+    }
+  }
+
+  console.log(`
+📋 To install actionlint (GitHub Actions static analysis):
+
+Option 1 - Homebrew (macOS/Linux):
+  brew install actionlint
+
+Option 2 - Script (Linux/macOS):
+  bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+
+Option 3 - GitHub releases:
+  https://github.com/rhysd/actionlint/releases
+
+Then run the validation command again.
+`);
+  throw new Error('Please install actionlint and try again');
+}
+
+/**
+ * Validates a GitHub Actions workflow file using act --list (dry validation, no Docker needed)
+ * @param yamlFilePath Path to the workflow file
+ * @returns Promise that resolves if the file is parseable by act
+ * @throws Error if act is not installed or the file is invalid
+ */
+export async function validateWithAct(yamlFilePath: string): Promise<void> {
+  const isInstalled = await isActInstalled();
+
+  if (!isInstalled) {
+    printActInstallInstructions();
+    throw new Error(
+      'act is not installed. Please install it to run GitHub Actions validation.'
+    );
+  }
+
+  try {
+    // act -l (list) validates workflow structure without running jobs or requiring Docker
+    const { stdout } = await execAsync(
+      `act -l --workflows "${yamlFilePath}" 2>&1`
+    );
+    console.log('✅ act validation passed');
+    if (stdout.trim()) {
+      console.log('act output:\n' + stdout.trim());
+    }
+  } catch (error: unknown) {
+    const execError = error as { stdout?: unknown; stderr?: unknown; message?: unknown };
+    const detail =
+      String(execError.stderr ?? execError.stdout ?? execError.message ?? '').trim();
+    throw new Error(`act validation failed${detail ? `\n\n${detail}` : ''}`);
+  }
+}
+
+/**
+ * Validates GitHub Actions YAML content using act (temp file wrapper)
+ * @param yamlContent The workflow YAML content as string
+ * @param tempFileName Optional temp file name
+ * @returns Promise that resolves if validation passes
+ */
+export async function validateGitHubActionsYamlWithAct(
+  yamlContent: string,
+  tempFileName: string = 'temp-github-workflow.yml'
+): Promise<void> {
+  const tempFilePath = path.join(os.tmpdir(), tempFileName);
+  try {
+    fs.writeFileSync(tempFilePath, yamlContent, 'utf8');
+    await validateWithAct(tempFilePath);
+  } finally {
+    try {
+      fs.unlinkSync(tempFilePath);
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+}
+
+/**
+ * Validates a GitHub Actions workflow file using actionlint (static analysis)
+ * @param yamlFilePath Path to the workflow file
+ * @param autoInstall Whether to auto-install actionlint if missing
+ * @returns Promise that resolves if validation passes
+ * @throws Error if actionlint is not installed or finds issues
+ */
+export async function validateWithActionlint(
+  yamlFilePath: string,
+  autoInstall: boolean = true
+): Promise<void> {
+  const isInstalled = await isActionlintInstalled();
+
+  if (!isInstalled) {
+    await installActionlint(autoInstall);
+    const isNowInstalled = await isActionlintInstalled();
+    if (!isNowInstalled) {
+      throw new Error('actionlint installation verification failed');
+    }
+  }
+
+  try {
+    const { stdout, stderr } = await execAsync(
+      `actionlint "${yamlFilePath}"`
+    );
+    console.log('✅ actionlint validation passed');
+    if (stdout.trim()) console.log('actionlint output:', stdout.trim());
+    if (stderr.trim()) console.log('actionlint warnings:', stderr.trim());
+  } catch (error: unknown) {
+    const execError = error as { stdout?: unknown; stderr?: unknown; message?: unknown };
+    const detail =
+      String(execError.stdout ?? execError.stderr ?? execError.message ?? '').trim();
+
+    if (detail.includes('Please install') || detail.includes('not found')) {
+      throw error;
+    }
+
+    let errorMessage = 'actionlint validation failed';
+    if (detail) errorMessage += `\n\nDetailed output:\n${detail}`;
+    throw new Error(errorMessage);
+  }
+}
+
+/**
+ * Validates GitHub Actions YAML content using actionlint (temp file wrapper)
+ * @param yamlContent The workflow YAML content as string
+ * @param tempFileName Optional temp file name
+ * @param autoInstall Whether to auto-install actionlint if missing
+ * @returns Promise that resolves if validation passes
+ */
+export async function validateGitHubActionsYamlWithActionlint(
+  yamlContent: string,
+  tempFileName: string = 'temp-actionlint.yml',
+  autoInstall: boolean = true
+): Promise<void> {
+  const tempFilePath = path.join(os.tmpdir(), tempFileName);
+  try {
+    fs.writeFileSync(tempFilePath, yamlContent, 'utf8');
+    await validateWithActionlint(tempFilePath, autoInstall);
+  } finally {
+    try {
+      fs.unlinkSync(tempFilePath);
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+}
+
+/**
  * Validates that the generated YAML is correctly structured and has no undefined values
  * @param yamlStr The YAML string to validate
  * @param enableBitriseCliValidation Whether to run Bitrise CLI validation (only works in CLI context, not browser)
  * @param enableYamllintValidation Whether to run yamllint validation for non-Bitrise workflows (only works in CLI context, not browser)
+ * @param enableActionlintValidation Whether to run actionlint static analysis for GitHub Actions workflows
+ * @param enableActValidation Whether to run act --list validation for GitHub Actions workflows
  * @returns The same YAML string if valid (or Promise<string> if async validation is enabled)
  * @throws Error if the YAML is invalid
  */
 export function validateGeneratedYaml(
   yamlStr: string,
   enableBitriseCliValidation: boolean = false,
-  enableYamllintValidation: boolean = false
+  enableYamllintValidation: boolean = false,
+  enableActionlintValidation: boolean = false,
+  enableActValidation: boolean = false,
 ): string | Promise<string> {
   try {
     // Try to parse the YAML to make sure it's valid
@@ -285,29 +520,32 @@ export function validateGeneratedYaml(
     validateNoUndefinedValues(parsedYaml);
     validateWorkflowStructure(parsedYaml);
 
-    // If Bitrise CLI validation is enabled and this is a Bitrise config, validate with Bitrise CLI
-    if (
-      enableBitriseCliValidation &&
+    const isBitriseConfig =
       parsedYaml &&
       typeof parsedYaml === 'object' &&
-      'format_version' in parsedYaml
-    ) {
-      // Return async validation for Bitrise configs when CLI validation is enabled
+      'format_version' in parsedYaml;
+
+    // Bitrise path: Bitrise CLI validation
+    if (isBitriseConfig && enableBitriseCliValidation) {
       return validateBitriseYamlAndReturn(yamlStr);
     }
 
-    // If yamllint validation is enabled and this is NOT a Bitrise config, validate with yamllint
-    if (
-      enableYamllintValidation &&
-      parsedYaml &&
-      typeof parsedYaml === 'object' &&
-      !('format_version' in parsedYaml)
-    ) {
-      // Return async validation for non-Bitrise configs (like GitHub Actions) when yamllint validation is enabled
-      return validateYamllintAndReturn(yamlStr);
+    // GitHub Actions path: yamllint → actionlint → act (each optional, chained)
+    if (!isBitriseConfig) {
+      const anyAsyncEnabled =
+        enableYamllintValidation || enableActionlintValidation || enableActValidation;
+
+      if (anyAsyncEnabled) {
+        return validateGitHubActionsAsync(
+          yamlStr,
+          enableYamllintValidation,
+          enableActionlintValidation,
+          enableActValidation
+        );
+      }
     }
 
-    // If validation passes, return the original string (sync)
+    // If all validation passes (or no async validation requested), return the original string
     return yamlStr;
   } catch (error) {
     throw new Error(`Invalid YAML generated: ${(error as Error).message}`);
@@ -315,22 +553,32 @@ export function validateGeneratedYaml(
 }
 
 /**
- * Helper function to validate Bitrise YAML content and return the original string
- * @param yamlStr The YAML string to validate and return
- * @returns Promise<string> The original YAML string if validation passes
+ * Runs the async GitHub Actions validation chain in order:
+ * yamllint → actionlint → act
  */
-async function validateBitriseYamlAndReturn(yamlStr: string): Promise<string> {
-  await validateBitriseYamlContent(yamlStr);
+async function validateGitHubActionsAsync(
+  yamlStr: string,
+  enableYamllint: boolean,
+  enableActionlint: boolean,
+  enableAct: boolean,
+): Promise<string> {
+  if (enableYamllint) {
+    await validateYamlContentWithYamllint(yamlStr, 'temp-gh-yamllint.yml', true, 'relaxed');
+  }
+  if (enableActionlint) {
+    await validateGitHubActionsYamlWithActionlint(yamlStr, 'temp-gh-actionlint.yml', true);
+  }
+  if (enableAct) {
+    await validateGitHubActionsYamlWithAct(yamlStr, 'temp-gh-act.yml');
+  }
   return yamlStr;
 }
 
 /**
- * Helper function to validate YAML content with yamllint and return the original string
- * @param yamlStr The YAML string to validate and return
- * @returns Promise<string> The original YAML string if validation passes
+ * Helper function to validate Bitrise YAML content and return the original string
  */
-async function validateYamllintAndReturn(yamlStr: string): Promise<string> {
-  await validateYamlContentWithYamllint(yamlStr, 'temp.yml', true, 'relaxed');
+async function validateBitriseYamlAndReturn(yamlStr: string): Promise<string> {
+  await validateBitriseYamlContent(yamlStr);
   return yamlStr;
 }
 


### PR DESCRIPTION
## Summary

- **308 tests across 17 suites** — all passing (up from ~50 tests with 6 failures)
- **6 new test files** covering integration, preset, secrets, and YAML validation paths end-to-end
- **actionlint + act integration** added to `validateGeneratedYaml`; new `github-validate` CLI command and `--validate-actionlint`/`--validate-act` flags on `generate`
- **Coverage thresholds** raised from 24–29% → 49–52% (branches/functions/lines/statements)
- **Pre-commit hook** now runs `yarn test` in addition to lint + type-check, so all tests gate every commit
- **4 bug fixes** included (previously broken behavior now corrected):
  - `notifications.ts`: missing "Setup GitHub CLI" step wired into PR comment notification pipeline
  - `storage.ts`: over-escaped `\${{` template strings in Firebase upload config
  - `.eslintignore` added to exclude `SampleExpoApp` (uses `@react-native` ESLint config not installed at root)
  - `SampleExpoApp` excluded from Jest (`testPathIgnorePatterns`) — it's a sample app, not library code
- **Known bugs documented** as current broken behavior in tests (bugs A, B, C, H, 1.2) with comments pointing to the PRs that will fix them

## Test plan

- [x] `yarn test` — 308/308 passing, 17/17 suites passing
- [x] `yarn lint` — 0 errors
- [x] `yarn type-check` — 0 errors
- [x] Pre-commit hook verified (commit above went through the full hook chain)
- [x] Snapshot tests generated for all presets — serve as regression baseline for future YAML changes