### PR TITLE
fix: align canonical URLs and sitemap to www domain

### DIFF
--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -14,7 +14,7 @@ const fontSans = FontSans({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://mobilecibuilder.com'),
+  metadataBase: new URL('https://www.mobilecibuilder.com'),
   title: 'React Native CI/CD Workflow Builder',
   description:
     'Generate GitHub Actions workflows for your React Native projects',

--- a/app/public/robots.txt
+++ b/app/public/robots.txt
@@ -3,4 +3,4 @@ User-agent: *
 Allow: /
 
 # Sitemap location
-Sitemap: https://mobilecibuilder.com/sitemap.xml
+Sitemap: https://www.mobilecibuilder.com/sitemap.xml

--- a/app/public/sitemap.xml
+++ b/app/public/sitemap.xml
@@ -8,48 +8,48 @@
 
 
 <url>
-  <loc>https://mobilecibuilder.com/</loc>
-  <lastmod>2025-07-08T08:27:09+00:00</lastmod>
+  <loc>https://www.mobilecibuilder.com/</loc>
+  <lastmod>2026-03-28T00:00:00+00:00</lastmod>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://mobilecibuilder.com/docs</loc>
-  <lastmod>2025-07-08T13:07:39+00:00</lastmod>
+  <loc>https://www.mobilecibuilder.com/docs</loc>
+  <lastmod>2026-03-28T00:00:00+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://mobilecibuilder.com/docs/getting-started</loc>
-  <lastmod>2025-07-08T13:07:40+00:00</lastmod>
+  <loc>https://www.mobilecibuilder.com/docs/getting-started</loc>
+  <lastmod>2026-03-28T00:00:00+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://mobilecibuilder.com/docs/core-concepts</loc>
-  <lastmod>2025-07-08T13:07:40+00:00</lastmod>
+  <loc>https://www.mobilecibuilder.com/docs/core-concepts</loc>
+  <lastmod>2026-03-28T00:00:00+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://mobilecibuilder.com/docs/workflow-presets</loc>
-  <lastmod>2025-07-08T13:07:40+00:00</lastmod>
+  <loc>https://www.mobilecibuilder.com/docs/workflow-presets</loc>
+  <lastmod>2026-03-28T00:00:00+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://mobilecibuilder.com/docs/configuration</loc>
-  <lastmod>2025-07-08T13:07:40+00:00</lastmod>
+  <loc>https://www.mobilecibuilder.com/docs/configuration</loc>
+  <lastmod>2026-03-28T00:00:00+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://mobilecibuilder.com/docs/storage-options</loc>
-  <lastmod>2025-07-08T13:07:40+00:00</lastmod>
+  <loc>https://www.mobilecibuilder.com/docs/storage-options</loc>
+  <lastmod>2026-03-28T00:00:00+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://mobilecibuilder.com/docs/secrets-management</loc>
-  <lastmod>2025-07-08T13:07:41+00:00</lastmod>
+  <loc>https://www.mobilecibuilder.com/docs/secrets-management</loc>
+  <lastmod>2026-03-28T00:00:00+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://mobilecibuilder.com/docs/benefits</loc>
-  <lastmod>2025-07-08T13:07:41+00:00</lastmod>
+  <loc>https://www.mobilecibuilder.com/docs/benefits</loc>
+  <lastmod>2026-03-28T00:00:00+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 


### PR DESCRIPTION
## Summary
- Update `metadataBase` in `layout.tsx` to `https://www.mobilecibuilder.com` — all `<link rel="canonical">` tags now resolve to the www domain that Vercel actually serves
- Update all 9 URLs in `sitemap.xml` from non-www to www, with refreshed `lastmod` dates
- Update `robots.txt` sitemap reference to www

## Problem
The site serves from `www.mobilecibuilder.com` (non-www redirects to www via Vercel), but canonical tags and sitemap were pointing to `mobilecibuilder.com` (non-www). This caused Google to see a contradiction:
1. Crawl `www.mobilecibuilder.com/docs` → canonical says `mobilecibuilder.com/docs`
2. Follow canonical → hits redirect back to www
3. Google can't resolve → "Duplicate without user-selected canonical" in GSC

## Test plan
- [ ] Deploy to production and verify `<link rel="canonical">` in page source reads `https://www.mobilecibuilder.com/...`
- [ ] Resubmit sitemap in GSC (`https://www.mobilecibuilder.com/sitemap.xml`)
- [ ] Request indexing for the 3 pages flagged as "Duplicate without user-selected canonical" in GSC
- [ ] Verify Vercel domain redirect is 308 (permanent), not 307 (temporary)