### PR TITLE
fix(ui): show correct next-steps instructions for Bitrise platform

### DIFF
--- a/app/components/workflow-builder.tsx
+++ b/app/components/workflow-builder.tsx
@@ -282,20 +282,34 @@ export function WorkflowBuilder() {
                 <Database className="h-5 w-5 text-primary" />
                 Next Steps
               </h3>
-              <ol className="list-inside list-decimal space-y-2 text-muted-foreground">
-                <li>
-                  Copy the generated workflow to a <code>.yml</code> file in
-                  your repository
-                </li>
-                <li>
-                  Place it in the <code>.github/workflows/</code> directory
-                </li>
-                <li>Commit and push to your GitHub repository</li>
-                <li>
-                  GitHub Actions will automatically run your workflow based on
-                  the triggers
-                </li>
-              </ol>
+              {formValues.platform === 'bitrise' ? (
+                <ol className="list-inside list-decimal space-y-2 text-muted-foreground">
+                  <li>
+                    Copy the generated YAML to a <code>bitrise.yml</code> file
+                    in your repository root
+                  </li>
+                  <li>Commit and push to your repository</li>
+                  <li>
+                    Bitrise will detect the <code>bitrise.yml</code> and run
+                    your workflow based on the configured triggers
+                  </li>
+                </ol>
+              ) : (
+                <ol className="list-inside list-decimal space-y-2 text-muted-foreground">
+                  <li>
+                    Copy the generated workflow to a <code>.yml</code> file in
+                    your repository
+                  </li>
+                  <li>
+                    Place it in the <code>.github/workflows/</code> directory
+                  </li>
+                  <li>Commit and push to your GitHub repository</li>
+                  <li>
+                    GitHub Actions will automatically run your workflow based on
+                    the triggers
+                  </li>
+                </ol>
+              )}
             </div>
           </TabsContent>
         </Tabs>


### PR DESCRIPTION
## Summary
- Bug 1.3: The Next Steps panel in the Preview tab always showed GitHub Actions instructions, regardless of the selected CI platform
- Fixed by conditionally rendering platform-specific instructions based on `formValues.platform`

**Bitrise instructions:**
1. Copy generated YAML to `bitrise.yml` in your repository root
2. Commit and push to your repository
3. Bitrise detects `bitrise.yml` and runs the workflow

**GitHub instructions (unchanged):**
1. Copy the generated workflow to a `.yml` file
2. Place it in the `.github/workflows/` directory
3. Commit and push to your GitHub repository
4. GitHub Actions runs automatically based on triggers

## Test plan
- [ ] Select Bitrise platform → preview workflow → Next Steps shows Bitrise instructions
- [ ] Select GitHub platform → preview workflow → Next Steps shows GitHub Actions instructions
- [ ] `npm test` passes (308 tests, no regressions — UI-only change)