### PR TITLE
fix(presets): respect nodeVersions in static analysis presets

### DIFF
--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -317,10 +317,10 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
     });
   });
 
-  // ─── nodeVersions: currently ignores all but first (bug 1.2 documented) ──
+  // ─── nodeVersions: matrix emitted for multiple versions (bug 1.2 fixed) ──
 
-  describe('nodeVersions handling (bug 1.2 — matrix not emitted)', () => {
-    it('uses only the first nodeVersion in the setup step (current broken behavior)', () => {
+  describe('nodeVersions handling', () => {
+    it('emits matrix strategy and uses matrix expression when multiple nodeVersions provided', () => {
       const { yaml: yamlStr } = generateWorkflow({
         kind: 'static-analysis',
         options: {
@@ -330,14 +330,25 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
       });
 
       const parsed = yaml.load(yamlStr) as Record<string, any>;
-      const setupNode = parsed.jobs.static_analysis.steps.find(
-        (s: any) => s.name === 'Setup Node'
-      );
+      const job = parsed.jobs.static_analysis;
+      const setupNode = job.steps.find((s: any) => s.name === 'Setup Node');
 
-      // Bug 1.2: only first node version used, no matrix strategy emitted
-      // After fix: should have strategy.matrix.node: [18, 20, 22]
-      expect(setupNode?.with?.['node-version']).toBe(18);
-      expect(parsed.jobs.static_analysis.strategy).toBeUndefined();
+      expect(job.strategy?.matrix?.['node-version']).toEqual([18, 20, 22]);
+      expect(setupNode?.with?.['node-version']).toBe('${{ matrix.node-version }}');
+    });
+
+    it('uses a direct version value (no matrix) when a single nodeVersion is provided', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: { platform: 'github', nodeVersions: [20] },
+      });
+
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      const job = parsed.jobs.static_analysis;
+      const setupNode = job.steps.find((s: any) => s.name === 'Setup Node');
+
+      expect(job.strategy).toBeUndefined();
+      expect(setupNode?.with?.['node-version']).toBe(20);
     });
   });
 

--- a/src/presets/__tests__/__snapshots__/bitriseStaticAnalysis.test.ts.snap
+++ b/src/presets/__tests__/__snapshots__/bitriseStaticAnalysis.test.ts.snap
@@ -47,10 +47,10 @@ exports[`buildBitriseStaticAnalysisPipeline output matches snapshot for default 
           "nvm@1": {
             "inputs": [
               {
-                "node_version": "18",
+                "node_version": "20",
               },
             ],
-            "title": "Setup Node.js 18",
+            "title": "Setup Node.js 20",
           },
         },
         {
@@ -191,10 +191,10 @@ exports[`buildBitriseStaticAnalysisPipeline output matches snapshot for npm pack
           "nvm@1": {
             "inputs": [
               {
-                "node_version": "18",
+                "node_version": "20",
               },
             ],
-            "title": "Setup Node.js 18",
+            "title": "Setup Node.js 20",
           },
         },
         {

--- a/src/presets/__tests__/bitriseStaticAnalysis.test.ts
+++ b/src/presets/__tests__/bitriseStaticAnalysis.test.ts
@@ -106,6 +106,38 @@ describe('buildBitriseStaticAnalysisPipeline', () => {
       expect(hasNvm).toBe(true);
     });
 
+    it('defaults nvm node_version to 20 when nodeVersions not provided', () => {
+      const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const nvmStep = steps.find((s: any) => 'nvm@1' in s) as any;
+      const nodeVersion = nvmStep?.['nvm@1']?.inputs?.[0]?.node_version;
+
+      expect(nodeVersion).toBe('20');
+    });
+
+    it('uses the first nodeVersions entry for nvm node_version', () => {
+      const result = buildBitriseStaticAnalysisPipeline({
+        ...defaultOptions,
+        nodeVersions: [18],
+      });
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const nvmStep = steps.find((s: any) => 'nvm@1' in s) as any;
+      const nodeVersion = nvmStep?.['nvm@1']?.inputs?.[0]?.node_version;
+
+      expect(nodeVersion).toBe('18');
+    });
+
+    it('reflects nodeVersions in nvm step title', () => {
+      const result = buildBitriseStaticAnalysisPipeline({
+        ...defaultOptions,
+        nodeVersions: [22],
+      });
+      const steps = result.workflows['rn-static-analysis'].steps;
+      const nvmStep = steps.find((s: any) => 'nvm@1' in s) as any;
+
+      expect(nvmStep?.['nvm@1']?.title).toBe('Setup Node.js 22');
+    });
+
     it('includes restore-cache step', () => {
       const result = buildBitriseStaticAnalysisPipeline(defaultOptions);
       const steps = result.workflows['rn-static-analysis'].steps;

--- a/src/presets/__tests__/staticAnalysis.test.ts
+++ b/src/presets/__tests__/staticAnalysis.test.ts
@@ -79,7 +79,18 @@ describe('buildStaticAnalysisPipeline', () => {
       expect(steps.some((s: any) => s.name === 'Setup Node')).toBe(true);
     });
 
-    it('uses the first nodeVersion for setup-node', () => {
+    it('uses the single nodeVersion directly for setup-node when only one version provided', () => {
+      const result = buildStaticAnalysisPipeline({
+        ...defaultOptions,
+        nodeVersions: [18],
+      });
+      const steps = result.jobs.static_analysis.steps;
+      const nodeStep = steps.find((s: any) => s.name === 'Setup Node') as any;
+
+      expect(nodeStep?.with?.['node-version']).toBe(18);
+    });
+
+    it('uses matrix expression for setup-node when multiple versions provided', () => {
       const result = buildStaticAnalysisPipeline({
         ...defaultOptions,
         nodeVersions: [18, 20],
@@ -87,7 +98,27 @@ describe('buildStaticAnalysisPipeline', () => {
       const steps = result.jobs.static_analysis.steps;
       const nodeStep = steps.find((s: any) => s.name === 'Setup Node') as any;
 
-      expect(nodeStep?.with?.['node-version']).toBe(18);
+      expect(nodeStep?.with?.['node-version']).toBe('${{ matrix.node-version }}');
+    });
+
+    it('adds strategy.matrix when multiple versions provided', () => {
+      const result = buildStaticAnalysisPipeline({
+        ...defaultOptions,
+        nodeVersions: [18, 20],
+      });
+      const job = result.jobs.static_analysis as any;
+
+      expect(job.strategy?.matrix?.['node-version']).toEqual([18, 20]);
+    });
+
+    it('does not add strategy when only one version provided', () => {
+      const result = buildStaticAnalysisPipeline({
+        ...defaultOptions,
+        nodeVersions: [20],
+      });
+      const job = result.jobs.static_analysis as any;
+
+      expect(job.strategy).toBeUndefined();
     });
   });
 

--- a/src/presets/bitriseStaticAnalysis.ts
+++ b/src/presets/bitriseStaticAnalysis.ts
@@ -7,6 +7,7 @@ export function buildBitriseStaticAnalysisPipeline(
     triggers,
     env,
     packageManager = 'yarn',
+    nodeVersions,
     framework = 'react-native-cli', // Default to React Native CLI if not specified
     staticAnalysis = {
       typescript: true,
@@ -75,10 +76,10 @@ export function buildBitriseStaticAnalysisPipeline(
     },
     {
       'nvm@1': {
-        title: 'Setup Node.js 18',
+        title: `Setup Node.js ${String(nodeVersions?.[0] ?? 20)}`,
         inputs: [
           {
-            node_version: '18',
+            node_version: String(nodeVersions?.[0] ?? 20),
           },
         ],
       },

--- a/src/presets/staticAnalysis.ts
+++ b/src/presets/staticAnalysis.ts
@@ -46,13 +46,17 @@ export function buildStaticAnalysisPipeline(
     }
   }
 
+  const isMultiVersion = nodeVersions.length > 1;
+
   const testSteps: GitHubStep[] = [
     { name: 'Checkout', uses: 'actions/checkout@v4' },
     {
       name: 'Setup Node',
       uses: 'actions/setup-node@v4',
       with: {
-        'node-version': nodeVersions[0] || 20,
+        'node-version': isMultiVersion
+          ? '${{ matrix.node-version }}'
+          : nodeVersions[0] || 20,
         cache: packageManager === 'yarn' ? 'yarn' : 'npm',
       },
     },
@@ -110,6 +114,9 @@ export function buildStaticAnalysisPipeline(
   const testJob: GitHubJob = {
     name: 'Run Static Analysis',
     'runs-on': runsOn,
+    ...(isMultiVersion
+      ? { strategy: { matrix: { 'node-version': nodeVersions } } }
+      : {}),
     steps: testSteps,
   };
 


### PR DESCRIPTION
## Summary
- **Bug 1.2** — `staticAnalysis` preset now emits a matrix strategy when multiple `nodeVersions` are provided. `setup-node` uses `${{ matrix.node-version }}` so each version is tested. Single-version behaviour is unchanged.
- **Bug 1.6** — `bitriseStaticAnalysis` no longer hardcodes Node 18. Uses `opts.nodeVersions[0] ?? 20` and reflects the version in the step title.

## Changes
- `src/presets/staticAnalysis.ts` — matrix strategy emitted when `nodeVersions.length > 1`
- `src/presets/bitriseStaticAnalysis.ts` — destructure `nodeVersions` from opts; replace hardcoded `'18'`
- Tests updated + new tests added for both presets
- Integration test updated from documenting the broken behavior to asserting the correct matrix output
- Snapshots updated to reflect new matrix output

## Test plan
- [x] `npm test` — 315 passing
- [x] Generate a static-analysis workflow with `nodeVersions: [18, 20, 22]` — confirm `strategy.matrix.node-version` is present
- [x] Generate a Bitrise static-analysis workflow — confirm NVM step uses version from config, not hardcoded 18