### PR TITLE
fix(generator): generate secrets summary for static-analysis with notifications

### DIFF
--- a/app/utils/lib.ts
+++ b/app/utils/lib.ts
@@ -10,11 +10,12 @@ import { buildBitriseBuildPipeline } from '../../src/presets/bitriseBuildPreset'
 import { buildBitriseStaticAnalysisPipeline } from '../../src/presets/bitriseStaticAnalysis';
 import { buildBuildPipeline } from '../../src/presets/buildPreset';
 import { buildStaticAnalysisPipeline } from '../../src/presets/staticAnalysis';
-import { 
-  WorkflowConfig, 
-  WorkflowOptions, 
-  BitriseConfig, 
-  GitHubWorkflow 
+import { BuildOptions, StaticAnalysisOptions } from '../../src/presets/types';
+import {
+  WorkflowConfig,
+  WorkflowOptions,
+  BitriseConfig,
+  GitHubWorkflow
 } from '../../src/types';
 
 // Map of pipeline builders (copied from generator.ts but without Node.js dependencies)
@@ -77,25 +78,27 @@ export function generateWorkflow(cfg: WorkflowConfig): {
   });
   yamlStr = injectSecrets(yamlStr);
 
-  // Generate secrets summary for build preset
+  // Generate secrets summary
   let secretsSummary: string | undefined;
-  if (
-    validatedConfig.kind === 'build' &&
-    validatedConfig.options &&
-    validatedConfig.options.build
-  ) {
+  if (validatedConfig.kind === 'build' && validatedConfig.options?.build) {
     try {
-      // Use the imported generateSecretsSummary function
-      if (validatedConfig.options && validatedConfig.options.build) {
-        // Make sure to include framework from options
-        const buildOptions = {
-          ...validatedConfig.options.build,
-          framework: validatedConfig.options.framework
-        };
-        secretsSummary = generateSecretsSummary(buildOptions);
-      }
+      const buildOptions: BuildOptions = {
+        ...validatedConfig.options.build,
+        framework: validatedConfig.options.framework,
+      };
+      secretsSummary = generateSecretsSummary(buildOptions);
     } catch (err) {
       console.error('Error generating secrets summary:', err);
+    }
+  } else if (validatedConfig.kind === 'static-analysis') {
+    // Validator strips staticAnalysis from options (bug H) — read from original cfg
+    const notification = (cfg.options?.staticAnalysis as StaticAnalysisOptions | undefined)?.notification;
+    if (notification === 'slack' || notification === 'both') {
+      try {
+        secretsSummary = generateSecretsSummary({ notification } as BuildOptions);
+      } catch (err) {
+        console.error('Error generating secrets summary:', err);
+      }
     }
   }
 

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -424,6 +424,69 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
     });
   });
 
+  // ─── Secrets summary: static-analysis (bug 1.5) ──────────────────────────
+
+  describe('Secrets summary — Static Analysis (bug 1.5)', () => {
+    it('returns a non-undefined secretsSummary containing SLACK_WEBHOOK when notification is slack', () => {
+      const { secretsSummary } = generateWorkflow({
+        kind: 'static-analysis',
+        options: {
+          platform: 'github',
+          staticAnalysis: { notification: 'slack' },
+        },
+      });
+
+      expect(secretsSummary).toBeDefined();
+      expect(secretsSummary).toContain('SLACK_WEBHOOK');
+    });
+
+    it('returns a non-undefined secretsSummary containing SLACK_WEBHOOK when notification is both', () => {
+      const { secretsSummary } = generateWorkflow({
+        kind: 'static-analysis',
+        options: {
+          platform: 'github',
+          staticAnalysis: { notification: 'both' },
+        },
+      });
+
+      expect(secretsSummary).toBeDefined();
+      expect(secretsSummary).toContain('SLACK_WEBHOOK');
+    });
+
+    it('returns undefined secretsSummary when notification is none', () => {
+      const { secretsSummary } = generateWorkflow({
+        kind: 'static-analysis',
+        options: {
+          platform: 'github',
+          staticAnalysis: { notification: 'none' },
+        },
+      });
+
+      expect(secretsSummary).toBeUndefined();
+    });
+
+    it('returns undefined secretsSummary when no staticAnalysis options are provided', () => {
+      const { secretsSummary } = generateWorkflow({
+        kind: 'static-analysis',
+        options: { platform: 'github' },
+      });
+
+      expect(secretsSummary).toBeUndefined();
+    });
+
+    it('returns undefined secretsSummary when notification is pr-comment', () => {
+      const { secretsSummary } = generateWorkflow({
+        kind: 'static-analysis',
+        options: {
+          platform: 'github',
+          staticAnalysis: { notification: 'pr-comment' },
+        },
+      });
+
+      expect(secretsSummary).toBeUndefined();
+    });
+  });
+
   // ─── Error cases ──────────────────────────────────────────────────────────
 
   describe('Error handling', () => {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -4,7 +4,7 @@ import path from 'path';
 
 import { injectSecrets } from './helpers';
 import { generateSecretsSummary } from './helpers/secretsManager';
-import { BuildOptions } from './presets/types';
+import { BuildOptions, StaticAnalysisOptions } from './presets/types';
 import {
   BitriseConfig,
   GitHubWorkflow,
@@ -109,6 +109,26 @@ export function clearBuilders(): void {
 }
 
 /**
+ * Generate a secrets summary for a static-analysis config.
+ * Returns a summary only when Slack notifications are configured
+ * (notification === 'slack' or 'both'), since those require SLACK_WEBHOOK_URL.
+ * Returns undefined when no secrets are needed.
+ */
+function generateStaticAnalysisSecretsSummary(
+  staticAnalysis: StaticAnalysisOptions | undefined
+): string | undefined {
+  const notification = staticAnalysis?.notification;
+  if (notification !== 'slack' && notification !== 'both') {
+    return undefined;
+  }
+  // Build a synthetic BuildOptions so we can reuse generateSecretsSummary.
+  // Only the notification field is relevant — storage and platform secrets
+  // do not apply to the static-analysis preset.
+  const syntheticBuildOptions: BuildOptions = { notification };
+  return generateSecretsSummary(syntheticBuildOptions);
+}
+
+/**
  * Generate a workflow YAML from config
  * @param cfg The workflow configuration
  * @returns Workflow YAML as string
@@ -144,12 +164,18 @@ export function generateWorkflow(cfg: WorkflowConfig): {
   // Validate the generated YAML (sync - for web app compatibility)
   const validatedYaml = validateGeneratedYaml(yamlStr, false) as string;
 
-  // Generate secrets summary for build preset
+  // Generate secrets summary for build preset and static-analysis with notifications
   let secretsSummary: string | undefined;
   if (validatedConfig.kind === 'build' && validatedConfig.options) {
     secretsSummary = generateSecretsSummary(
       (validatedConfig.options as WorkflowOptions & { build?: BuildOptions })
         .build || ({} as BuildOptions)
+    );
+  } else if (validatedConfig.kind === 'static-analysis') {
+    // Note: the validator currently strips `staticAnalysis` from options (bug H).
+    // Read from the original cfg to ensure notification settings are visible.
+    secretsSummary = generateStaticAnalysisSecretsSummary(
+      cfg.options?.staticAnalysis
     );
   }
 
@@ -207,12 +233,18 @@ export async function generateWorkflowForCli(
     console.warn('Skipping YAML validation:', e);
   }
 
-  // Generate secrets summary for build preset
+  // Generate secrets summary for build preset and static-analysis with notifications
   let secretsSummary: string | undefined;
   if (validatedConfig.kind === 'build' && validatedConfig.options) {
     secretsSummary = generateSecretsSummary(
       (validatedConfig.options as WorkflowOptions & { build?: BuildOptions })
         .build || ({} as BuildOptions)
+    );
+  } else if (validatedConfig.kind === 'static-analysis') {
+    // Note: the validator currently strips `staticAnalysis` from options (bug H).
+    // Read from the original cfg to ensure notification settings are visible.
+    secretsSummary = generateStaticAnalysisSecretsSummary(
+      cfg.options?.staticAnalysis
     );
   }
 


### PR DESCRIPTION
## Summary
Bug 1.5: When the `static-analysis` preset was configured with Slack notifications, `SLACK_WEBHOOK_URL` was never surfaced in the secrets summary output. Users had no indication that a secret was required.

## What changed
- Added `generateStaticAnalysisSecretsSummary()` helper in `src/generator.ts`
- Both `generateWorkflow` and `generateWorkflowForCli` now call it for `kind === 'static-analysis'`
- Delegates to the existing `generateSecretsSummary` function to reuse formatting — no duplication
- Reads `staticAnalysis` from the original `cfg.options` (not `validatedConfig.options`) to work around the existing validator-stripping bug (bug H)

## Behaviour
| `notification` | `secretsSummary` |
|---|---|
| `'slack'` | Defined — contains `SLACK_WEBHOOK_URL` |
| `'both'` | Defined — contains `SLACK_WEBHOOK_URL` |
| `'pr-comment'` | `undefined` (no secrets needed) |
| `'none'` / absent | `undefined` |

## Test plan
- [x] 313 tests passing
- [x] 5 new integration tests under `'Secrets summary — Static Analysis (bug 1.5)'`
- [x] Generate a static-analysis workflow with `notification: 'slack'` — confirm `secretsSummary` is returned and contains `SLACK_WEBHOOK`