### PR TITLE
fix: debounce YAML preview regeneration (300ms)

### DIFF
--- a/app/components/workflow-builder.tsx
+++ b/app/components/workflow-builder.tsx
@@ -100,17 +100,20 @@ export function WorkflowBuilder() {
   const [isGenerating, setIsGenerating] = useState(false);
   const [activeTab, setActiveTab] = useState('configure');
 
-  // Generate YAML when form values change or on initial load
+  // Generate YAML when form values change, debounced to avoid regenerating on every keystroke
   useEffect(() => {
-    try {
-      const config = createConfigFromFormValues(formValues);
-      const result = generateWorkflowYaml(config);
-      setYamlContent(result.yaml);
-      setSecretsSummary(result.secretsSummary);
-    } catch (error) {
-      console.error('Error generating YAML:', error);
-      // Keep the previous valid YAML
-    }
+    const timer = setTimeout(() => {
+      try {
+        const config = createConfigFromFormValues(formValues);
+        const result = generateWorkflowYaml(config);
+        setYamlContent(result.yaml);
+        setSecretsSummary(result.secretsSummary);
+      } catch (error) {
+        console.error('Error generating YAML:', error);
+        // Keep the previous valid YAML
+      }
+    }, 300);
+    return () => clearTimeout(timer);
   }, [formValues]);
 
   const handleFormChange = (newValues: Record<string, unknown>) => {


### PR DESCRIPTION
## Summary
- The `useEffect` watching `formValues` fired synchronously on every state change, including every keystroke in text inputs like the workflow name field
- Added a 300ms debounce using `setTimeout`/`clearTimeout` — generation only runs after the user pauses
- The explicit "Generate" button click path (`handleGenerateClick`) remains instant

## Test plan
- [ ] Type in the workflow name field — preview should not re-render on every character, only after 300ms pause
- [ ] Change a dropdown (platform, preset) — preview updates within 300ms
- [ ] Click the Generate button — preview updates instantly