### PR TITLE
refactor: clean up platforms.ts — replace IIFEs and remove deprecated params

### DIFF
--- a/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -437,7 +437,6 @@ cd android
 }
 cd ..
 
-
 echo "✅ Android build completed successfully"
 
 # Verify the expected outputs based on output type
@@ -606,7 +605,6 @@ cd android
   exit 1
 }
 cd ..
-
 
 echo "✅ Android build completed successfully"
 

--- a/src/helpers/__tests__/platforms.test.ts
+++ b/src/helpers/__tests__/platforms.test.ts
@@ -18,8 +18,6 @@ describe('Platform Helpers', () => {
 
       const steps = platformHelpers.createAndroidBuildSteps(
         mockSetupSteps,
-        'npm',
-        '',
         buildOptions
       );
 
@@ -55,8 +53,6 @@ describe('Platform Helpers', () => {
 
       const steps = platformHelpers.createAndroidBuildSteps(
         mockSetupSteps,
-        'npm',
-        '',
         buildOptions
       );
 
@@ -75,8 +71,6 @@ describe('Platform Helpers', () => {
 
       const steps = platformHelpers.createAndroidBuildSteps(
         mockSetupSteps,
-        'npm',
-        '',
         buildOptions
       );
 
@@ -96,8 +90,6 @@ describe('Platform Helpers', () => {
 
       const steps = platformHelpers.createAndroidBuildSteps(
         mockSetupSteps,
-        'npm',
-        '',
         buildOptions
       );
 
@@ -115,8 +107,6 @@ describe('Platform Helpers', () => {
 
       const steps = platformHelpers.createAndroidBuildSteps(
         mockSetupSteps,
-        'npm',
-        '',
         buildOptions
       );
 
@@ -137,8 +127,6 @@ describe('Platform Helpers', () => {
 
       const steps = platformHelpers.createAndroidBuildSteps(
         mockSetupSteps,
-        'npm',
-        '',
         buildOptions
       );
 
@@ -167,8 +155,6 @@ describe('Platform Helpers', () => {
 
       const steps = platformHelpers.createIOSBuildSteps(
         mockSetupSteps,
-        'npm',
-        '',
         buildOptions
       );
 
@@ -208,8 +194,6 @@ describe('Platform Helpers', () => {
 
       const steps = platformHelpers.createIOSBuildSteps(
         mockSetupSteps,
-        'npm',
-        '',
         buildOptions
       );
 
@@ -227,8 +211,6 @@ describe('Platform Helpers', () => {
 
       const steps = platformHelpers.createIOSBuildSteps(
         mockSetupSteps,
-        'npm',
-        '',
         buildOptions
       );
 
@@ -250,8 +232,6 @@ describe('Platform Helpers', () => {
 
       const steps = platformHelpers.createIOSBuildSteps(
         mockSetupSteps,
-        'npm',
-        '',
         buildOptions
       );
 
@@ -271,8 +251,6 @@ describe('Platform Helpers', () => {
 
       const steps = platformHelpers.createIOSBuildSteps(
         mockSetupSteps,
-        'npm',
-        '',
         buildOptions
       );
 
@@ -290,8 +268,6 @@ describe('Platform Helpers', () => {
 
       const steps = platformHelpers.createIOSBuildSteps(
         mockSetupSteps,
-        'npm',
-        '',
         buildOptions
       );
 

--- a/src/helpers/platforms.ts
+++ b/src/helpers/platforms.ts
@@ -1,6 +1,89 @@
 import { BuildOptions } from '../presets/types';
 import { GitHubStep, PackageManager } from '../types';
 
+function androidGradleCommands(
+  variant: BuildOptions['variant'],
+  outputType: string
+): string {
+  if (outputType === 'both') {
+    const apkTask = variant === 'debug' ? 'assembleDebug' : 'assembleRelease';
+    const aabTask = variant === 'debug' ? 'bundleDebug' : 'bundleRelease';
+    return `echo "Generating both APK and AAB formats for ${variant} build"
+
+# First generate APK (installable app format)
+echo "Using Gradle task: ${apkTask} for ${variant} build with APK output format"
+cd android
+./gradlew ${apkTask} || {
+  echo "❌ Android APK build failed"
+  echo "::error::Android APK build failed. Check logs for details."
+  exit 1
+}
+cd ..
+
+
+# Then generate AAB (app bundle format for Play Store)
+echo "Using Gradle task: ${aabTask} for ${variant} build with AAB output format"
+cd android
+./gradlew ${aabTask} || {
+  echo "❌ Android AAB build failed"
+  echo "::error::Android AAB build failed. Check logs for details."
+  exit 1
+}
+cd ..
+`;
+  }
+
+  const task =
+    outputType === 'apk'
+      ? variant === 'debug'
+        ? 'assembleDebug'
+        : 'assembleRelease'
+      : variant === 'debug'
+        ? 'bundleDebug'
+        : 'bundleRelease';
+
+  return `echo "Using Gradle task: ${task} for ${variant} build with ${outputType} output format"
+
+# Using direct Gradle command
+cd android
+./gradlew ${task} || {
+  echo "❌ Android build failed"
+  echo "::error::Android build failed. Check logs for details."
+  exit 1
+}
+cd ..
+`;
+}
+
+function androidOutputVerification(outputType: string): string {
+  if (outputType === 'both') {
+    return `# Check for both APK and AAB files
+if ls android/app/build/outputs/apk/**/*.apk 1> /dev/null 2>&1; then
+  echo "✅ APK files generated successfully"
+else
+  echo "⚠️ Warning: Expected APK files not found. Storage steps may fail."
+fi
+
+if ls android/app/build/outputs/bundle/**/*.aab 1> /dev/null 2>&1; then
+  echo "✅ AAB files generated successfully"
+else
+  echo "⚠️ Warning: Expected AAB files not found. Storage steps may fail."
+fi`;
+  } else if (outputType === 'apk') {
+    return `if ls android/app/build/outputs/apk/**/*.apk 1> /dev/null 2>&1; then
+  echo "✅ APK files generated successfully"
+else
+  echo "⚠️ Warning: Expected APK files not found. Storage steps may fail."
+fi`;
+  } else {
+    return `if ls android/app/build/outputs/bundle/**/*.aab 1> /dev/null 2>&1; then
+  echo "✅ AAB files generated successfully"
+else
+  echo "⚠️ Warning: Expected AAB files not found. Storage steps may fail."
+fi`;
+  }
+}
+
 /**
  * Platform-specific workflow step helpers
  */
@@ -10,15 +93,12 @@ const platformHelpers = {
    *
    * @param setupSteps Common setup steps like checkout and Node setup
    * @param packageManager Package manager to use for installing dependencies
-   * @param buildParams DEPRECATED: No longer used directly, kept for API compatibility
    * @param build Build options specifying platform and output type
    * @returns Array of GitHub Actions workflow steps
    */
   createExpoBuildSteps(
     setupSteps: GitHubStep[],
     packageManager: PackageManager,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    buildParams: string,
     build: BuildOptions
   ): GitHubStep[] {
     // Platform-aware build steps
@@ -78,17 +158,11 @@ const platformHelpers = {
    * Creates Android-specific build steps for GitHub Actions workflow
    *
    * @param setupSteps Common setup steps like checkout and Node setup
-   * @param packageManager DEPRECATED: No longer used directly, kept for API compatibility
-   * @param buildParams DEPRECATED: No longer used directly, kept for API compatibility
    * @param build Build options specifying platform, variant, and output type
    * @returns Array of GitHub Actions workflow steps
    */
   createAndroidBuildSteps(
     setupSteps: GitHubStep[],
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    packageManager: PackageManager,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    buildParams: string,
     build: BuildOptions
   ): GitHubStep[] {
     return [
@@ -149,124 +223,11 @@ fi
 echo "Building Android app using official React Native CLI..."
 
 # Using direct Gradle commands for more reliable builds
-${(() => {
-  /**
-   * This IIFE dynamically generates the Gradle build commands based on the specified variant and output type.
-   *
-   * The complex logic handles:
-   * 1. Different build variants (debug/release)
-   * 2. Different output formats (APK/AAB/both)
-   * 3. Appropriate Gradle tasks for each combination
-   * 4. Proper error handling for each build command
-   */
-
-  // Determine the appropriate Gradle task based on variant and output type
-  const variant = build.variant;
-  const outputType = build.androidOutputType || 'apk'; // Default to APK if not specified
-
-  if (outputType === 'both') {
-    // When building both APK and AAB formats, we need to run two separate Gradle tasks
-
-    // Select the appropriate task name based on build variant
-    const apkTask = variant === 'debug' ? 'assembleDebug' : 'assembleRelease';
-    const aabTask = variant === 'debug' ? 'bundleDebug' : 'bundleRelease';
-
-    return `echo "Generating both APK and AAB formats for ${variant} build"
-
-# First generate APK (installable app format)
-echo "Using Gradle task: ${apkTask} for ${variant} build with APK output format"
-cd android
-./gradlew ${apkTask} || {
-  echo "❌ Android APK build failed"
-  echo "::error::Android APK build failed. Check logs for details."
-  exit 1
-}
-cd ..
-
-
-# Then generate AAB (app bundle format for Play Store)
-echo "Using Gradle task: ${aabTask} for ${variant} build with AAB output format"
-cd android
-./gradlew ${aabTask} || {
-  echo "❌ Android AAB build failed"
-  echo "::error::Android AAB build failed. Check logs for details."
-  exit 1
-}
-cd ..
-`;
-  } else {
-    // For single output type (either APK or AAB)
-    let task = '';
-
-    if (outputType === 'apk') {
-      // APK format (standard Android package)
-      task = variant === 'debug' ? 'assembleDebug' : 'assembleRelease';
-    } else {
-      // AAB format (Android App Bundle for Google Play)
-      task = variant === 'debug' ? 'bundleDebug' : 'bundleRelease';
-    }
-
-    return `echo "Using Gradle task: ${task} for ${variant} build with ${outputType} output format"
-
-# Using direct Gradle command
-cd android
-./gradlew ${task} || {
-  echo "❌ Android build failed"
-  echo "::error::Android build failed. Check logs for details."
-  exit 1
-}
-cd ..
-`;
-  }
-})()}
-
+${androidGradleCommands(build.variant, build.androidOutputType || 'apk')}
 echo "✅ Android build completed successfully"
 
 # Verify the expected outputs based on output type
-${(() => {
-  /**
-   * Verifies that build outputs were generated properly based on the selected output type.
-   *
-   * This code dynamically checks for:
-   * - APK files in the correct output directory (for APK output type)
-   * - AAB files in the bundle directory (for AAB output type)
-   * - Both file types when both output formats are requested
-   *
-   * If files aren't found, a warning is shown but the workflow continues,
-   * as some build setups may place files in different locations.
-   */
-  const outputType = build.androidOutputType || 'apk';
-
-  if (outputType === 'both') {
-    // When building both formats, check for both file types
-    return `# Check for both APK and AAB files
-if ls android/app/build/outputs/apk/**/*.apk 1> /dev/null 2>&1; then
-  echo "✅ APK files generated successfully"
-else
-  echo "⚠️ Warning: Expected APK files not found. Storage steps may fail."
-fi
-
-if ls android/app/build/outputs/bundle/**/*.aab 1> /dev/null 2>&1; then
-  echo "✅ AAB files generated successfully"
-else
-  echo "⚠️ Warning: Expected AAB files not found. Storage steps may fail."
-fi`;
-  } else if (outputType === 'apk') {
-    // For APK only output, check just the APK files
-    return `if ls android/app/build/outputs/apk/**/*.apk 1> /dev/null 2>&1; then
-  echo "✅ APK files generated successfully"
-else
-  echo "⚠️ Warning: Expected APK files not found. Storage steps may fail."
-fi`;
-  } else {
-    // For AAB only output, check just the AAB files
-    return `if ls android/app/build/outputs/bundle/**/*.aab 1> /dev/null 2>&1; then
-  echo "✅ AAB files generated successfully"
-else
-  echo "⚠️ Warning: Expected AAB files not found. Storage steps may fail."
-fi`;
-  }
-})()}
+${androidOutputVerification(build.androidOutputType || 'apk')}
 `,
       },
       // Artifact storage is handled by the storage helper based on the storage configuration
@@ -277,17 +238,11 @@ fi`;
    * Creates iOS-specific build steps for GitHub Actions workflow
    *
    * @param setupSteps Common setup steps like checkout and Node setup
-   * @param packageManager DEPRECATED: No longer used directly, kept for API compatibility
-   * @param buildParams DEPRECATED: No longer used directly, kept for API compatibility
    * @param build Build options specifying platform and variant
    * @returns Array of GitHub Actions workflow steps
    */
   createIOSBuildSteps(
     setupSteps: GitHubStep[],
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    packageManager: PackageManager,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    buildParams: string,
     build: BuildOptions
   ): GitHubStep[] {
     return [

--- a/src/presets/buildPreset.ts
+++ b/src/presets/buildPreset.ts
@@ -137,7 +137,6 @@ export function buildBuildPipeline(opts: WorkflowOptions): GitHubWorkflow {
       buildJob.steps = platformHelpers.createExpoBuildSteps(
         setupSteps,
         packageManager,
-        '',
         build
       );
 
@@ -154,17 +153,10 @@ export function buildBuildPipeline(opts: WorkflowOptions): GitHubWorkflow {
       if (platform === 'android') {
         buildJob.steps = platformHelpers.createAndroidBuildSteps(
           setupSteps,
-          packageManager,
-          '',
           build
         );
       } else if (platform === 'ios') {
-        buildJob.steps = platformHelpers.createIOSBuildSteps(
-          setupSteps,
-          packageManager,
-          '',
-          build
-        );
+        buildJob.steps = platformHelpers.createIOSBuildSteps(setupSteps, build);
       }
 
       // Add storage steps if configured


### PR DESCRIPTION
## Summary
- Extract two anonymous IIFEs from `createAndroidBuildSteps` into module-level functions `androidGradleCommands()` and `androidOutputVerification()` — no behavior change, just readability (Phase 4.3)
- Remove the `buildParams: string` DEPRECATED param from all three platform helpers; remove the `packageManager: PackageManager` DEPRECATED param from `createAndroidBuildSteps` and `createIOSBuildSteps` — these params were already ignored and suppressed with `eslint-disable` (Phase 4.5)
- Update callers in `buildPreset.ts` and all test calls accordingly
- Update two integration snapshots (one fewer blank line in the Android build step script — cosmetic difference from IIFE removal)

## Test plan
- [x] All 325 unit/integration tests pass (`yarn test`)
- [x] Type-check passes (`yarn type-check`)
- [x] Lint passes (`yarn lint:ci`)
- [x] Prettier passes (`yarn format:check`)
- [x] CI passes on this PR