### PR TITLE
fix: enable Bitrise platform in workflow builder UI

### DIFF
--- a/app/components/workflow-form.tsx
+++ b/app/components/workflow-form.tsx
@@ -187,12 +187,7 @@ export function WorkflowForm({ values, onChange }: WorkflowFormProps) {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="github">GitHub Actions</SelectItem>
-                  <SelectItem value="bitrise" disabled={true}>
-                    Bitrise
-                    <span className="ml-2 rounded-full bg-amber-200 px-2 py-0.5 text-xs font-medium text-amber-800">
-                      Coming Soon
-                    </span>
-                  </SelectItem>
+                  <SelectItem value="bitrise">Bitrise</SelectItem>
                 </SelectContent>
               </Select>
               <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- Removes the `disabled` flag and "Coming Soon" badge from the Bitrise option in the CI platform dropdown
- Bitrise workflow generation was already fully implemented; this change makes it selectable in the web UI

## Test plan
- [x] Open the web form and verify Bitrise appears as a selectable option in the CI Platform dropdown
- [x] Select Bitrise and confirm the YAML preview shows a valid `bitrise.yml` configuration
- [x] All existing tests pass (`yarn test`)