### PR TITLE
feat: add GitLab CI platform support

### DIFF
--- a/app/components/workflow-form.tsx
+++ b/app/components/workflow-form.tsx
@@ -187,12 +187,7 @@ export function WorkflowForm({ values, onChange }: WorkflowFormProps) {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="github">GitHub Actions</SelectItem>
-                  <SelectItem value="bitrise" disabled={true}>
-                    Bitrise
-                    <span className="ml-2 rounded-full bg-amber-200 px-2 py-0.5 text-xs font-medium text-amber-800">
-                      Coming Soon
-                    </span>
-                  </SelectItem>
+                  <SelectItem value="bitrise">Bitrise</SelectItem>
                 </SelectContent>
               </Select>
               <p className="text-xs text-muted-foreground">

--- a/app/components/workflow-form.tsx
+++ b/app/components/workflow-form.tsx
@@ -188,12 +188,15 @@ export function WorkflowForm({ values, onChange }: WorkflowFormProps) {
                 <SelectContent>
                   <SelectItem value="github">GitHub Actions</SelectItem>
                   <SelectItem value="bitrise">Bitrise</SelectItem>
+                  <SelectItem value="gitlab">GitLab CI</SelectItem>
                 </SelectContent>
               </Select>
               <p className="text-xs text-muted-foreground">
                 {values.platform === 'bitrise'
                   ? 'Generate a Bitrise workflow configuration (bitrise.yml)'
-                  : 'Generate a GitHub Actions workflow (.github/workflows/*.yml)'}
+                  : values.platform === 'gitlab'
+                    ? 'Generate a GitLab CI configuration (.gitlab-ci.yml)'
+                    : 'Generate a GitHub Actions workflow (.github/workflows/*.yml)'}
               </p>
             </div>
 

--- a/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -960,3 +960,52 @@ gh pr comment $PR_NUM --body "$MESSAGE"
   },
 }
 `;
+
+exports[`Integration: Full Workflow Generation Pipeline GitLab CI — Build (Android) output structure matches snapshot 1`] = `
+"stages:
+  - build
+build:
+  image: node:20
+  stage: build
+  cache:
+    key: $CI_COMMIT_REF_SLUG
+    paths:
+      - node_modules/
+  script:
+    - yarn install --immutable
+    - yarn tsc --noEmit
+    - yarn lint
+    - yarn test --ci
+    - chmod +x android/gradlew
+    - cd android && ./gradlew assembleRelease && cd ..
+  artifacts:
+    paths:
+      - android/app/build/outputs/apk/**/*.apk
+    expire_in: 30 days
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+"
+`;
+
+exports[`Integration: Full Workflow Generation Pipeline GitLab CI — Static Analysis output structure matches snapshot 1`] = `
+"stages:
+  - static-analysis
+static-analysis:
+  image: node:20
+  stage: static-analysis
+  cache:
+    key: $CI_COMMIT_REF_SLUG
+    paths:
+      - node_modules/
+  script:
+    - yarn install --immutable
+    - yarn tsc --noEmit
+    - yarn lint
+    - yarn format:check
+    - yarn test --ci
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+"
+`;

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -576,4 +576,62 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
       ).toThrow();
     });
   });
+
+  // ─── GitLab CI ───────────────────────────────────────────────────────────
+
+  describe('GitLab CI — Static Analysis', () => {
+    it('generates valid parseable YAML with yarn', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: { platform: 'gitlab', packageManager: 'yarn', nodeVersions: [20] },
+      });
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      expect(parsed.stages).toContain('static-analysis');
+      expect(parsed['static-analysis'].image).toBe('node:20');
+    });
+
+    it('includes TypeScript check in script', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: { platform: 'gitlab', packageManager: 'yarn', nodeVersions: [18] },
+      });
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      const script: string[] = parsed['static-analysis'].script;
+      expect(script.some(s => s.includes('tsc'))).toBe(true);
+    });
+
+    it('output structure matches snapshot', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: { platform: 'gitlab', packageManager: 'yarn', nodeVersions: [20] },
+      });
+      expect(yamlStr).toMatchSnapshot();
+    });
+  });
+
+  describe('GitLab CI — Build (Android)', () => {
+    it('generates valid parseable YAML', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'build',
+        options: {
+          platform: 'gitlab',
+          build: { platform: 'android', variant: 'release', storage: 'github', notification: 'none' },
+        },
+      });
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      expect(parsed.stages).toContain('build');
+      expect(parsed.build.artifacts).toBeDefined();
+    });
+
+    it('output structure matches snapshot', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'build',
+        options: {
+          platform: 'gitlab',
+          build: { platform: 'android', variant: 'release', storage: 'github', notification: 'none' },
+        },
+      });
+      expect(yamlStr).toMatchSnapshot();
+    });
+  });
 });

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -583,7 +583,11 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
     it('generates valid parseable YAML with yarn', () => {
       const { yaml: yamlStr } = generateWorkflow({
         kind: 'static-analysis',
-        options: { platform: 'gitlab', packageManager: 'yarn', nodeVersions: [20] },
+        options: {
+          platform: 'gitlab',
+          packageManager: 'yarn',
+          nodeVersions: [20],
+        },
       });
       const parsed = yaml.load(yamlStr) as Record<string, any>;
       expect(parsed.stages).toContain('static-analysis');
@@ -593,7 +597,11 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
     it('includes TypeScript check in script', () => {
       const { yaml: yamlStr } = generateWorkflow({
         kind: 'static-analysis',
-        options: { platform: 'gitlab', packageManager: 'yarn', nodeVersions: [18] },
+        options: {
+          platform: 'gitlab',
+          packageManager: 'yarn',
+          nodeVersions: [18],
+        },
       });
       const parsed = yaml.load(yamlStr) as Record<string, any>;
       const script: string[] = parsed['static-analysis'].script;
@@ -603,7 +611,11 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
     it('output structure matches snapshot', () => {
       const { yaml: yamlStr } = generateWorkflow({
         kind: 'static-analysis',
-        options: { platform: 'gitlab', packageManager: 'yarn', nodeVersions: [20] },
+        options: {
+          platform: 'gitlab',
+          packageManager: 'yarn',
+          nodeVersions: [20],
+        },
       });
       expect(yamlStr).toMatchSnapshot();
     });
@@ -615,7 +627,12 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
         kind: 'build',
         options: {
           platform: 'gitlab',
-          build: { platform: 'android', variant: 'release', storage: 'github', notification: 'none' },
+          build: {
+            platform: 'android',
+            variant: 'release',
+            storage: 'github',
+            notification: 'none',
+          },
         },
       });
       const parsed = yaml.load(yamlStr) as Record<string, any>;
@@ -628,7 +645,12 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
         kind: 'build',
         options: {
           platform: 'gitlab',
-          build: { platform: 'android', variant: 'release', storage: 'github', notification: 'none' },
+          build: {
+            platform: 'android',
+            variant: 'release',
+            storage: 'github',
+            notification: 'none',
+          },
         },
       });
       expect(yamlStr).toMatchSnapshot();

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -224,12 +224,18 @@ export function writeWorkflowFile(
   let outputFileName = fileName;
 
   if (!outputDir) {
-    outputDir = platform === 'bitrise' ? '.' : '.github/workflows';
+    if (platform === 'bitrise' || platform === 'gitlab') {
+      outputDir = '.';
+    } else {
+      outputDir = '.github/workflows';
+    }
   }
 
   if (!outputFileName) {
     if (platform === 'bitrise') {
       outputFileName = 'bitrise.yml';
+    } else if (platform === 'gitlab') {
+      outputFileName = '.gitlab-ci.yml';
     } else {
       outputFileName = `${cfg.kind}.yaml`;
     }

--- a/src/presets/__tests__/__snapshots__/gitlabBuildPreset.test.ts.snap
+++ b/src/presets/__tests__/__snapshots__/gitlabBuildPreset.test.ts.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildGitlabBuildPipeline output matches snapshot for default options 1`] = `
+{
+  "build": {
+    "artifacts": {
+      "expire_in": "30 days",
+      "paths": [
+        "android/app/build/outputs/apk/**/*.apk",
+      ],
+    },
+    "cache": {
+      "key": "$CI_COMMIT_REF_SLUG",
+      "paths": [
+        "node_modules/",
+      ],
+    },
+    "image": "node:20",
+    "rules": [
+      {
+        "if": "$CI_PIPELINE_SOURCE == "push"",
+      },
+      {
+        "if": "$CI_PIPELINE_SOURCE == "merge_request_event"",
+      },
+    ],
+    "script": [
+      "yarn install --immutable",
+      "chmod +x android/gradlew",
+      "cd android && ./gradlew assembleRelease && cd ..",
+    ],
+    "stage": "build",
+  },
+  "stages": [
+    "build",
+  ],
+}
+`;

--- a/src/presets/__tests__/__snapshots__/gitlabStaticAnalysis.test.ts.snap
+++ b/src/presets/__tests__/__snapshots__/gitlabStaticAnalysis.test.ts.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildGitlabStaticAnalysisPipeline output matches snapshot for default options 1`] = `
+{
+  "stages": [
+    "static-analysis",
+  ],
+  "static-analysis": {
+    "cache": {
+      "key": "$CI_COMMIT_REF_SLUG",
+      "paths": [
+        "node_modules/",
+      ],
+    },
+    "image": "node:20",
+    "rules": [
+      {
+        "if": "$CI_PIPELINE_SOURCE == "push"",
+      },
+      {
+        "if": "$CI_PIPELINE_SOURCE == "merge_request_event"",
+      },
+    ],
+    "script": [
+      "yarn install --immutable",
+      "yarn tsc --noEmit",
+      "yarn lint",
+      "yarn format:check",
+      "yarn test --ci",
+    ],
+    "stage": "static-analysis",
+  },
+}
+`;
+
+exports[`buildGitlabStaticAnalysisPipeline output matches snapshot for npm package manager 1`] = `
+{
+  "stages": [
+    "static-analysis",
+  ],
+  "static-analysis": {
+    "cache": {
+      "key": "$CI_COMMIT_REF_SLUG",
+      "paths": [
+        "node_modules/",
+      ],
+    },
+    "image": "node:20",
+    "rules": [
+      {
+        "if": "$CI_PIPELINE_SOURCE == "push"",
+      },
+      {
+        "if": "$CI_PIPELINE_SOURCE == "merge_request_event"",
+      },
+    ],
+    "script": [
+      "npm ci",
+      "npm run tsc -- --noEmit",
+      "npm run lint",
+      "npm run format:check",
+      "npm test -- --ci",
+    ],
+    "stage": "static-analysis",
+  },
+}
+`;

--- a/src/presets/__tests__/gitlabBuildPreset.test.ts
+++ b/src/presets/__tests__/gitlabBuildPreset.test.ts
@@ -1,0 +1,137 @@
+import { buildGitlabBuildPipeline } from '../gitlabBuildPreset';
+import { WorkflowOptions } from '../../types';
+
+describe('buildGitlabBuildPipeline', () => {
+  const defaultOptions: WorkflowOptions = {
+    platform: 'gitlab',
+    packageManager: 'yarn',
+    build: {
+      platform: 'android',
+      variant: 'release',
+      androidOutputType: 'apk',
+      storage: 'github',
+      notification: 'none',
+      includeStaticAnalysis: false,
+    },
+  };
+
+  describe('output structure', () => {
+    it('returns stages and build job', () => {
+      const result = buildGitlabBuildPipeline(defaultOptions);
+
+      expect(result.stages).toEqual(['build']);
+      expect(result['build']).toBeDefined();
+    });
+
+    it('uses the correct node Docker image', () => {
+      const result = buildGitlabBuildPipeline({
+        ...defaultOptions,
+        nodeVersions: [20],
+      });
+      const job = result['build'] as Record<string, unknown>;
+
+      expect(job.image).toBe('node:20');
+    });
+
+    it('includes artifacts section', () => {
+      const result = buildGitlabBuildPipeline(defaultOptions);
+      const job = result['build'] as Record<string, unknown>;
+
+      expect(job.artifacts).toBeDefined();
+    });
+
+    it('sets artifact expire_in to 30 days', () => {
+      const result = buildGitlabBuildPipeline(defaultOptions);
+      const job = result['build'] as Record<string, unknown>;
+      const artifacts = job.artifacts as Record<string, unknown>;
+
+      expect(artifacts.expire_in).toBe('30 days');
+    });
+  });
+
+  describe('build commands', () => {
+    it('includes assembleRelease for release APK build', () => {
+      const result = buildGitlabBuildPipeline(defaultOptions);
+      const job = result['build'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('assembleRelease'))).toBe(true);
+    });
+
+    it('includes assembleDebug for debug build', () => {
+      const result = buildGitlabBuildPipeline({
+        ...defaultOptions,
+        build: { ...defaultOptions.build, variant: 'debug' },
+      });
+      const job = result['build'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('assembleDebug'))).toBe(true);
+    });
+
+    it('includes bundleRelease for AAB output', () => {
+      const result = buildGitlabBuildPipeline({
+        ...defaultOptions,
+        build: { ...defaultOptions.build, androidOutputType: 'aab' },
+      });
+      const job = result['build'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('bundleRelease'))).toBe(true);
+    });
+
+    it('includes both assemble and bundle tasks for both output', () => {
+      const result = buildGitlabBuildPipeline({
+        ...defaultOptions,
+        build: { ...defaultOptions.build, androidOutputType: 'both' },
+      });
+      const job = result['build'] as Record<string, unknown>;
+      const script = job.script as string[];
+      const buildCmd = script.find(s => s.includes('assembleRelease') || s.includes('assembleDebug')) ?? '';
+
+      expect(buildCmd).toContain('assembleRelease');
+      expect(buildCmd).toContain('bundleRelease');
+    });
+  });
+
+  describe('static analysis', () => {
+    it('includes TypeScript check when includeStaticAnalysis is true', () => {
+      const result = buildGitlabBuildPipeline({
+        ...defaultOptions,
+        build: { ...defaultOptions.build, includeStaticAnalysis: true },
+      });
+      const job = result['build'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('tsc'))).toBe(true);
+    });
+
+    it('excludes TypeScript check when includeStaticAnalysis is false', () => {
+      const result = buildGitlabBuildPipeline(defaultOptions);
+      const job = result['build'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('tsc'))).toBe(false);
+    });
+  });
+
+  describe('notifications', () => {
+    it('adds Slack after_script when notification is slack', () => {
+      const result = buildGitlabBuildPipeline({
+        ...defaultOptions,
+        build: { ...defaultOptions.build, notification: 'slack' },
+      });
+      const job = result['build'] as Record<string, unknown>;
+
+      expect(job.after_script).toBeDefined();
+      const afterScript = job.after_script as string[];
+      expect(afterScript.some(s => s.includes('SLACK_WEBHOOK_URL'))).toBe(true);
+    });
+  });
+
+  it('output matches snapshot for default options', () => {
+    const result = buildGitlabBuildPipeline(defaultOptions);
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/src/presets/__tests__/gitlabBuildPreset.test.ts
+++ b/src/presets/__tests__/gitlabBuildPreset.test.ts
@@ -87,7 +87,10 @@ describe('buildGitlabBuildPipeline', () => {
       });
       const job = result['build'] as Record<string, unknown>;
       const script = job.script as string[];
-      const buildCmd = script.find(s => s.includes('assembleRelease') || s.includes('assembleDebug')) ?? '';
+      const buildCmd =
+        script.find(
+          s => s.includes('assembleRelease') || s.includes('assembleDebug')
+        ) ?? '';
 
       expect(buildCmd).toContain('assembleRelease');
       expect(buildCmd).toContain('bundleRelease');

--- a/src/presets/__tests__/gitlabStaticAnalysis.test.ts
+++ b/src/presets/__tests__/gitlabStaticAnalysis.test.ts
@@ -1,0 +1,178 @@
+import { buildGitlabStaticAnalysisPipeline } from '../gitlabStaticAnalysis';
+import { WorkflowOptions } from '../../types';
+
+describe('buildGitlabStaticAnalysisPipeline', () => {
+  const defaultOptions: WorkflowOptions = {
+    platform: 'gitlab',
+    packageManager: 'yarn',
+  };
+
+  describe('output structure', () => {
+    it('returns stages and static-analysis job', () => {
+      const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+
+      expect(result.stages).toEqual(['static-analysis']);
+      expect(result['static-analysis']).toBeDefined();
+    });
+
+    it('uses the correct node Docker image', () => {
+      const result = buildGitlabStaticAnalysisPipeline({
+        ...defaultOptions,
+        nodeVersions: [20],
+      });
+      const job = result['static-analysis'] as Record<string, unknown>;
+
+      expect(job.image).toBe('node:20');
+    });
+
+    it('uses a custom node version', () => {
+      const result = buildGitlabStaticAnalysisPipeline({
+        ...defaultOptions,
+        nodeVersions: [18],
+      });
+      const job = result['static-analysis'] as Record<string, unknown>;
+
+      expect(job.image).toBe('node:18');
+    });
+
+    it('includes cache configuration', () => {
+      const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+      const job = result['static-analysis'] as Record<string, unknown>;
+
+      expect(job.cache).toBeDefined();
+    });
+
+    it('includes rules', () => {
+      const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+      const job = result['static-analysis'] as Record<string, unknown>;
+
+      expect(Array.isArray(job.rules)).toBe(true);
+      expect((job.rules as unknown[]).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('scripts', () => {
+    it('uses yarn install --immutable for yarn', () => {
+      const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+      const job = result['static-analysis'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script[0]).toBe('yarn install --immutable');
+    });
+
+    it('uses npm ci for npm', () => {
+      const result = buildGitlabStaticAnalysisPipeline({
+        ...defaultOptions,
+        packageManager: 'npm',
+      });
+      const job = result['static-analysis'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script[0]).toBe('npm ci');
+    });
+
+    it('includes TypeScript check by default', () => {
+      const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+      const job = result['static-analysis'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('tsc'))).toBe(true);
+    });
+
+    it('excludes TypeScript check when disabled', () => {
+      const result = buildGitlabStaticAnalysisPipeline({
+        ...defaultOptions,
+        staticAnalysis: { typescript: false },
+      });
+      const job = result['static-analysis'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('tsc'))).toBe(false);
+    });
+
+    it('includes ESLint by default', () => {
+      const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+      const job = result['static-analysis'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('lint'))).toBe(true);
+    });
+
+    it('includes Prettier by default', () => {
+      const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+      const job = result['static-analysis'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('format:check'))).toBe(true);
+    });
+
+    it('includes unit tests by default', () => {
+      const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+      const job = result['static-analysis'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('test'))).toBe(true);
+    });
+  });
+
+  describe('triggers', () => {
+    it('defaults to push and MR rules when no triggers configured', () => {
+      const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+      const job = result['static-analysis'] as Record<string, unknown>;
+      const rules = job.rules as Array<Record<string, string>>;
+
+      expect(rules.some(r => r.if?.includes('push'))).toBe(true);
+      expect(rules.some(r => r.if?.includes('merge_request'))).toBe(true);
+    });
+
+    it('uses custom push branches when provided', () => {
+      const result = buildGitlabStaticAnalysisPipeline({
+        ...defaultOptions,
+        triggers: { push: { branches: ['develop'] } },
+      });
+      const job = result['static-analysis'] as Record<string, unknown>;
+      const rules = job.rules as Array<Record<string, string>>;
+
+      expect(rules.some(r => r.if?.includes('develop'))).toBe(true);
+    });
+  });
+
+  describe('notifications', () => {
+    it('adds after_script for Slack notification', () => {
+      const result = buildGitlabStaticAnalysisPipeline({
+        ...defaultOptions,
+        staticAnalysis: { notification: 'slack' },
+      });
+      const job = result['static-analysis'] as Record<string, unknown>;
+
+      expect(job.after_script).toBeDefined();
+      const afterScript = job.after_script as string[];
+      expect(afterScript.some(s => s.includes('SLACK_WEBHOOK_URL'))).toBe(true);
+    });
+
+    it('does not add after_script when notification is none', () => {
+      const result = buildGitlabStaticAnalysisPipeline({
+        ...defaultOptions,
+        staticAnalysis: { notification: 'none' },
+      });
+      const job = result['static-analysis'] as Record<string, unknown>;
+
+      expect(job.after_script).toBeUndefined();
+    });
+  });
+
+  it('output matches snapshot for default options', () => {
+    const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('output matches snapshot for npm package manager', () => {
+    const result = buildGitlabStaticAnalysisPipeline({
+      ...defaultOptions,
+      packageManager: 'npm',
+    });
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/src/presets/gitlabBuildPreset.ts
+++ b/src/presets/gitlabBuildPreset.ts
@@ -1,0 +1,149 @@
+import { WorkflowOptions } from '../types';
+import { BuildOptions } from './types';
+
+export function buildGitlabBuildPipeline(
+  opts: WorkflowOptions
+): Record<string, unknown> {
+  const {
+    triggers,
+    nodeVersions = [20],
+    packageManager = 'yarn',
+    framework = 'react-native-cli',
+    build = {
+      platform: 'android',
+      variant: 'release',
+      androidOutputType: 'apk',
+      storage: 'github',
+      notification: 'none',
+      includeStaticAnalysis: false,
+    },
+  } = opts;
+
+  const nodeVersion = nodeVersions[0] ?? 20;
+  const installCmd =
+    packageManager === 'yarn' ? 'yarn install --immutable' : 'npm ci';
+  const buildOpts = build as BuildOptions;
+
+  // Scripts array
+  const script: string[] = [installCmd];
+
+  // Static analysis steps
+  if (buildOpts.includeStaticAnalysis) {
+    script.push(
+      packageManager === 'yarn'
+        ? 'yarn tsc --noEmit'
+        : 'npm run tsc -- --noEmit'
+    );
+    script.push(
+      packageManager === 'yarn' ? 'yarn lint' : 'npm run lint'
+    );
+    script.push(
+      packageManager === 'yarn' ? 'yarn test --ci' : 'npm test -- --ci'
+    );
+  }
+
+  // Build command
+  if (framework === 'expo') {
+    script.push('npm install -g eas-cli');
+    const outputFlag =
+      buildOpts.androidOutputType === 'aab' ? 'production' : 'production-apk';
+    script.push(
+      `eas build --platform android --profile ${outputFlag} --local --non-interactive`
+    );
+  } else {
+    script.push('chmod +x android/gradlew');
+    const variant = buildOpts.variant ?? 'release';
+    const outputType = buildOpts.androidOutputType ?? 'apk';
+
+    if (outputType === 'both') {
+      const apkTask =
+        variant === 'debug' ? 'assembleDebug' : 'assembleRelease';
+      const aabTask = variant === 'debug' ? 'bundleDebug' : 'bundleRelease';
+      script.push(`cd android && ./gradlew ${apkTask} ${aabTask} && cd ..`);
+    } else if (outputType === 'aab') {
+      const task = variant === 'debug' ? 'bundleDebug' : 'bundleRelease';
+      script.push(`cd android && ./gradlew ${task} && cd ..`);
+    } else {
+      const task =
+        variant === 'debug' ? 'assembleDebug' : 'assembleRelease';
+      script.push(`cd android && ./gradlew ${task} && cd ..`);
+    }
+  }
+
+  // Build rules from triggers
+  const rules: Array<Record<string, unknown>> = [];
+
+  if (triggers?.push?.branches && triggers.push.branches.length > 0) {
+    const branchPattern = triggers.push.branches.join('|');
+    rules.push({
+      if: `$CI_COMMIT_BRANCH =~ /(${branchPattern})/`,
+    });
+  }
+
+  if (triggers?.pullRequest) {
+    rules.push({ if: '$CI_PIPELINE_SOURCE == "merge_request_event"' });
+  }
+
+  if (triggers?.schedule) {
+    rules.push({ if: '$CI_PIPELINE_SOURCE == "schedule"' });
+  }
+
+  if (triggers?.workflowDispatch) {
+    rules.push({ if: '$CI_PIPELINE_SOURCE == "web"' });
+  }
+
+  if (rules.length === 0) {
+    rules.push(
+      { if: '$CI_PIPELINE_SOURCE == "push"' },
+      { if: '$CI_PIPELINE_SOURCE == "merge_request_event"' }
+    );
+  }
+
+  // Artifact paths
+  const artifactPaths: string[] = [];
+  const outputType = buildOpts.androidOutputType ?? 'apk';
+  if (framework === 'expo') {
+    artifactPaths.push('expo-builds/');
+  } else {
+    if (outputType === 'apk' || outputType === 'both') {
+      artifactPaths.push('android/app/build/outputs/apk/**/*.apk');
+    }
+    if (outputType === 'aab' || outputType === 'both') {
+      artifactPaths.push('android/app/build/outputs/bundle/**/*.aab');
+    }
+  }
+
+  // Slack notification
+  const afterScript: string[] = [];
+  if (
+    buildOpts.notification === 'slack' ||
+    buildOpts.notification === 'both'
+  ) {
+    afterScript.push(
+      `curl -s -X POST -H 'Content-type: application/json' ` +
+        `--data '{"text":"Android build completed on branch: $CI_COMMIT_BRANCH"}' ` +
+        `"$SLACK_WEBHOOK_URL" || true`
+    );
+  }
+
+  const job: Record<string, unknown> = {
+    image: `node:${nodeVersion}`,
+    stage: 'build',
+    cache: {
+      key: '$CI_COMMIT_REF_SLUG',
+      paths: ['node_modules/'],
+    },
+    script,
+    artifacts: {
+      paths: artifactPaths,
+      expire_in: '30 days',
+    },
+    ...(afterScript.length > 0 ? { after_script: afterScript } : {}),
+    rules,
+  };
+
+  return {
+    stages: ['build'],
+    build: job,
+  };
+}

--- a/src/presets/gitlabBuildPreset.ts
+++ b/src/presets/gitlabBuildPreset.ts
@@ -34,9 +34,7 @@ export function buildGitlabBuildPipeline(
         ? 'yarn tsc --noEmit'
         : 'npm run tsc -- --noEmit'
     );
-    script.push(
-      packageManager === 'yarn' ? 'yarn lint' : 'npm run lint'
-    );
+    script.push(packageManager === 'yarn' ? 'yarn lint' : 'npm run lint');
     script.push(
       packageManager === 'yarn' ? 'yarn test --ci' : 'npm test -- --ci'
     );
@@ -56,16 +54,14 @@ export function buildGitlabBuildPipeline(
     const outputType = buildOpts.androidOutputType ?? 'apk';
 
     if (outputType === 'both') {
-      const apkTask =
-        variant === 'debug' ? 'assembleDebug' : 'assembleRelease';
+      const apkTask = variant === 'debug' ? 'assembleDebug' : 'assembleRelease';
       const aabTask = variant === 'debug' ? 'bundleDebug' : 'bundleRelease';
       script.push(`cd android && ./gradlew ${apkTask} ${aabTask} && cd ..`);
     } else if (outputType === 'aab') {
       const task = variant === 'debug' ? 'bundleDebug' : 'bundleRelease';
       script.push(`cd android && ./gradlew ${task} && cd ..`);
     } else {
-      const task =
-        variant === 'debug' ? 'assembleDebug' : 'assembleRelease';
+      const task = variant === 'debug' ? 'assembleDebug' : 'assembleRelease';
       script.push(`cd android && ./gradlew ${task} && cd ..`);
     }
   }
@@ -115,10 +111,7 @@ export function buildGitlabBuildPipeline(
 
   // Slack notification
   const afterScript: string[] = [];
-  if (
-    buildOpts.notification === 'slack' ||
-    buildOpts.notification === 'both'
-  ) {
+  if (buildOpts.notification === 'slack' || buildOpts.notification === 'both') {
     afterScript.push(
       `curl -s -X POST -H 'Content-type: application/json' ` +
         `--data '{"text":"Android build completed on branch: $CI_COMMIT_BRANCH"}' ` +

--- a/src/presets/gitlabStaticAnalysis.ts
+++ b/src/presets/gitlabStaticAnalysis.ts
@@ -29,15 +29,11 @@ export function buildGitlabStaticAnalysisPipeline(
     );
   }
   if (staticAnalysis.eslint !== false) {
-    script.push(
-      packageManager === 'yarn' ? 'yarn lint' : 'npm run lint'
-    );
+    script.push(packageManager === 'yarn' ? 'yarn lint' : 'npm run lint');
   }
   if (staticAnalysis.prettier !== false) {
     script.push(
-      packageManager === 'yarn'
-        ? 'yarn format:check'
-        : 'npm run format:check'
+      packageManager === 'yarn' ? 'yarn format:check' : 'npm run format:check'
     );
   }
   if (staticAnalysis.unitTests !== false) {

--- a/src/presets/gitlabStaticAnalysis.ts
+++ b/src/presets/gitlabStaticAnalysis.ts
@@ -1,0 +1,108 @@
+import { WorkflowOptions } from '../types';
+
+export function buildGitlabStaticAnalysisPipeline(
+  opts: WorkflowOptions
+): Record<string, unknown> {
+  const {
+    triggers,
+    nodeVersions = [20],
+    packageManager = 'yarn',
+    staticAnalysis = {
+      typescript: true,
+      eslint: true,
+      prettier: true,
+      unitTests: true,
+    },
+  } = opts;
+
+  const nodeVersion = nodeVersions[0] ?? 20;
+  const installCmd =
+    packageManager === 'yarn' ? 'yarn install --immutable' : 'npm ci';
+
+  const script: string[] = [installCmd];
+
+  if (staticAnalysis.typescript !== false) {
+    script.push(
+      packageManager === 'yarn'
+        ? 'yarn tsc --noEmit'
+        : 'npm run tsc -- --noEmit'
+    );
+  }
+  if (staticAnalysis.eslint !== false) {
+    script.push(
+      packageManager === 'yarn' ? 'yarn lint' : 'npm run lint'
+    );
+  }
+  if (staticAnalysis.prettier !== false) {
+    script.push(
+      packageManager === 'yarn'
+        ? 'yarn format:check'
+        : 'npm run format:check'
+    );
+  }
+  if (staticAnalysis.unitTests !== false) {
+    script.push(
+      packageManager === 'yarn' ? 'yarn test --ci' : 'npm test -- --ci'
+    );
+  }
+
+  // Build rules from triggers
+  const rules: Array<Record<string, unknown>> = [];
+
+  if (triggers?.push?.branches && triggers.push.branches.length > 0) {
+    const branchPattern = triggers.push.branches.join('|');
+    rules.push({
+      if: `$CI_COMMIT_BRANCH =~ /(${branchPattern})/`,
+    });
+  }
+
+  if (triggers?.pullRequest) {
+    rules.push({ if: '$CI_PIPELINE_SOURCE == "merge_request_event"' });
+  }
+
+  if (triggers?.schedule) {
+    rules.push({ if: '$CI_PIPELINE_SOURCE == "schedule"' });
+  }
+
+  if (triggers?.workflowDispatch) {
+    rules.push({ if: '$CI_PIPELINE_SOURCE == "web"' });
+  }
+
+  // Default rules when none configured
+  if (rules.length === 0) {
+    rules.push(
+      { if: '$CI_PIPELINE_SOURCE == "push"' },
+      { if: '$CI_PIPELINE_SOURCE == "merge_request_event"' }
+    );
+  }
+
+  // Slack notification via after_script
+  const afterScript: string[] = [];
+  if (
+    staticAnalysis.notification === 'slack' ||
+    staticAnalysis.notification === 'both'
+  ) {
+    afterScript.push(
+      `curl -s -X POST -H 'Content-type: application/json' ` +
+        `--data '{"text":"Static analysis completed on branch: $CI_COMMIT_BRANCH"}' ` +
+        `"$SLACK_WEBHOOK_URL" || true`
+    );
+  }
+
+  const job: Record<string, unknown> = {
+    image: `node:${nodeVersion}`,
+    stage: 'static-analysis',
+    cache: {
+      key: '$CI_COMMIT_REF_SLUG',
+      paths: ['node_modules/'],
+    },
+    script,
+    ...(afterScript.length > 0 ? { after_script: afterScript } : {}),
+    rules,
+  };
+
+  return {
+    stages: ['static-analysis'],
+    'static-analysis': job,
+  };
+}

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -6,27 +6,30 @@ import { WorkflowOptions } from '../types';
 import { buildBitriseBuildPipeline } from './bitriseBuildPreset';
 import { buildBitriseStaticAnalysisPipeline } from './bitriseStaticAnalysis';
 import { buildBuildPipeline } from './buildPreset';
+import { buildGitlabBuildPipeline } from './gitlabBuildPreset';
+import { buildGitlabStaticAnalysisPipeline } from './gitlabStaticAnalysis';
 import { buildStaticAnalysisPipeline } from './staticAnalysis';
 
 // Register all built-in presets here
 export function registerBuiltInPresets(): void {
-  // GitHub Actions builders
   registerBuilder('static-analysis', (opts: WorkflowOptions) => {
-    // Default to GitHub Actions if no platform specified
     if (!opts.platform || opts.platform === 'github') {
       return buildStaticAnalysisPipeline(opts);
     } else if (opts.platform === 'bitrise') {
       return buildBitriseStaticAnalysisPipeline(opts);
+    } else if (opts.platform === 'gitlab') {
+      return buildGitlabStaticAnalysisPipeline(opts);
     }
     throw new Error(`Unsupported platform: ${opts.platform}`);
   });
 
   registerBuilder('build', (opts: WorkflowOptions) => {
-    // Default to GitHub Actions if no platform specified
     if (!opts.platform || opts.platform === 'github') {
       return buildBuildPipeline(opts);
     } else if (opts.platform === 'bitrise') {
       return buildBitriseBuildPipeline(opts);
+    } else if (opts.platform === 'gitlab') {
+      return buildGitlabBuildPipeline(opts);
     }
     throw new Error(`Unsupported platform: ${opts.platform}`);
   });
@@ -36,6 +39,8 @@ export function registerBuiltInPresets(): void {
 export * from './bitriseBuildPreset';
 export * from './bitriseStaticAnalysis';
 export * from './buildPreset';
+export * from './gitlabBuildPreset';
+export * from './gitlabStaticAnalysis';
 export * from './staticAnalysis';
 export * from './types';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export type PipelineKind = 'static-analysis' | 'build';
 /**
  * Available CI platforms
  */
-export type CIPlatform = 'github' | 'bitrise';
+export type CIPlatform = 'github' | 'bitrise' | 'gitlab';
 
 /**
  * GitHub Actions workflow trigger configuration

--- a/src/validation/schema.ts
+++ b/src/validation/schema.ts
@@ -90,7 +90,7 @@ function validateWorkflowOptionsSchema(
   if (options.platform !== undefined) {
     validatedOptions.platform = validateEnum(
       options.platform,
-      ['github', 'bitrise'],
+      ['github', 'bitrise', 'gitlab'],
       'platform'
     ) as WorkflowOptions['platform'];
   }

--- a/src/validation/yaml.ts
+++ b/src/validation/yaml.ts
@@ -913,17 +913,20 @@ function validateWorkflowStructure(parsedYaml: unknown): void {
     throw new Error('Generated workflow is not a valid object');
   }
 
-  // Detect if this is a Bitrise configuration or GitHub Actions workflow
-  if (
-    typeof parsedYaml === 'object' &&
-    parsedYaml &&
-    'format_version' in parsedYaml
-  ) {
-    // This is a Bitrise configuration
-    validateBitriseStructure(parsedYaml as Record<string, unknown>);
-  } else if (typeof parsedYaml === 'object' && parsedYaml) {
-    // This is a GitHub Actions workflow
-    validateGitHubActionsStructure(parsedYaml as Record<string, unknown>);
+  const obj = parsedYaml as Record<string, unknown>;
+
+  // Detect platform by distinctive top-level keys
+  if ('format_version' in obj) {
+    // Bitrise configuration
+    validateBitriseStructure(obj);
+  } else if ('stages' in obj && !('jobs' in obj)) {
+    // GitLab CI — must have at least one stage
+    if (!Array.isArray(obj.stages) || obj.stages.length === 0) {
+      throw new Error('GitLab CI configuration must have at least one stage');
+    }
+  } else {
+    // GitHub Actions workflow
+    validateGitHubActionsStructure(obj);
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds GitLab CI as a selectable platform in the workflow builder (UI dropdown + description text)
- Implements `gitlabStaticAnalysis` and `gitlabBuildPreset` presets generating `.gitlab-ci.yml`
- Extends `CIPlatform` type, schema validator, YAML structure validator, and generator output paths
- Adds unit tests for both presets and integration tests via `generateWorkflow()` API

## Technical notes
- GitLab CI config is detected in the YAML validator by the presence of a top-level `stages` array without a top-level `jobs` key
- Output file: `.gitlab-ci.yml` in the project root
- Build preset supports Android (APK/AAB/both) with configurable triggers and artifact retention

> **Note:** This PR stacks on top of `fix/enable-bitrise-platform` (#55). Merge that first, or review the diff scoped to this branch's commits.

## Test plan
- [ ] Select "GitLab CI" in the web form and verify a `.gitlab-ci.yml` preview is shown
- [ ] Verify `stages: [static-analysis]` appears in the static analysis preview
- [ ] Verify build preset includes Gradle build command and artifact paths
- [ ] `yarn test` passes (360 tests)