### PR TITLE
feat: add CircleCI platform support

### DIFF
--- a/app/components/workflow-form.tsx
+++ b/app/components/workflow-form.tsx
@@ -187,12 +187,7 @@ export function WorkflowForm({ values, onChange }: WorkflowFormProps) {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="github">GitHub Actions</SelectItem>
-                  <SelectItem value="bitrise" disabled={true}>
-                    Bitrise
-                    <span className="ml-2 rounded-full bg-amber-200 px-2 py-0.5 text-xs font-medium text-amber-800">
-                      Coming Soon
-                    </span>
-                  </SelectItem>
+                  <SelectItem value="bitrise">Bitrise</SelectItem>
                 </SelectContent>
               </Select>
               <p className="text-xs text-muted-foreground">

--- a/app/components/workflow-form.tsx
+++ b/app/components/workflow-form.tsx
@@ -188,12 +188,15 @@ export function WorkflowForm({ values, onChange }: WorkflowFormProps) {
                 <SelectContent>
                   <SelectItem value="github">GitHub Actions</SelectItem>
                   <SelectItem value="bitrise">Bitrise</SelectItem>
+                  <SelectItem value="gitlab">GitLab CI</SelectItem>
                 </SelectContent>
               </Select>
               <p className="text-xs text-muted-foreground">
                 {values.platform === 'bitrise'
                   ? 'Generate a Bitrise workflow configuration (bitrise.yml)'
-                  : 'Generate a GitHub Actions workflow (.github/workflows/*.yml)'}
+                  : values.platform === 'gitlab'
+                    ? 'Generate a GitLab CI configuration (.gitlab-ci.yml)'
+                    : 'Generate a GitHub Actions workflow (.github/workflows/*.yml)'}
               </p>
             </div>
 

--- a/app/components/workflow-form.tsx
+++ b/app/components/workflow-form.tsx
@@ -189,6 +189,7 @@ export function WorkflowForm({ values, onChange }: WorkflowFormProps) {
                   <SelectItem value="github">GitHub Actions</SelectItem>
                   <SelectItem value="bitrise">Bitrise</SelectItem>
                   <SelectItem value="gitlab">GitLab CI</SelectItem>
+                  <SelectItem value="circleci">CircleCI</SelectItem>
                 </SelectContent>
               </Select>
               <p className="text-xs text-muted-foreground">
@@ -196,7 +197,9 @@ export function WorkflowForm({ values, onChange }: WorkflowFormProps) {
                   ? 'Generate a Bitrise workflow configuration (bitrise.yml)'
                   : values.platform === 'gitlab'
                     ? 'Generate a GitLab CI configuration (.gitlab-ci.yml)'
-                    : 'Generate a GitHub Actions workflow (.github/workflows/*.yml)'}
+                    : values.platform === 'circleci'
+                      ? 'Generate a CircleCI configuration (.circleci/config.yml)'
+                      : 'Generate a GitHub Actions workflow (.github/workflows/*.yml)'}
               </p>
             </div>
 

--- a/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -347,6 +347,88 @@ yarn test --ci",
 }
 `;
 
+exports[`Integration: Full Workflow Generation Pipeline CircleCI — Build (Android) output structure matches snapshot 1`] = `
+"version: 2.1
+orbs:
+  node: circleci/node@5
+jobs:
+  build:
+    docker:
+      - image: cimg/android:2024.01
+    environment:
+      NODE_VERSION: '20'
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: yarn
+
+      - run:
+          name: TypeScript
+          command: yarn tsc --noEmit
+
+      - run:
+          name: ESLint
+          command: yarn lint
+
+      - run:
+          name: Unit Tests
+          command: yarn test --ci
+
+      - run:
+          name: Make gradlew executable
+          command: chmod +x android/gradlew
+
+      - run:
+          name: Build Android
+          command: cd android && ./gradlew assembleRelease && cd ..
+          no_output_timeout: 30m
+
+      - store_artifacts:
+          path: android/app/build/outputs/apk
+
+workflows:
+  build:
+    jobs:
+      - build: {}
+"
+`;
+
+exports[`Integration: Full Workflow Generation Pipeline CircleCI — Static Analysis output structure matches snapshot 1`] = `
+"version: 2.1
+orbs:
+  node: circleci/node@5
+jobs:
+  static-analysis:
+    docker:
+      - image: cimg/node:20.0
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: yarn
+
+      - run:
+          name: TypeScript
+          command: yarn tsc --noEmit
+
+      - run:
+          name: ESLint
+          command: yarn lint
+
+      - run:
+          name: Prettier
+          command: yarn format:check
+
+      - run:
+          name: Unit Tests
+          command: yarn test --ci
+
+workflows:
+  static-analysis:
+    jobs:
+      - static-analysis: {}
+"
+`;
+
 exports[`Integration: Full Workflow Generation Pipeline GitHub Actions — Build (Android) output structure matches snapshot 1`] = `
 {
   "env": {},
@@ -959,4 +1041,53 @@ gh pr comment $PR_NUM --body "$MESSAGE"
     },
   },
 }
+`;
+
+exports[`Integration: Full Workflow Generation Pipeline GitLab CI — Build (Android) output structure matches snapshot 1`] = `
+"stages:
+  - build
+build:
+  image: node:20
+  stage: build
+  cache:
+    key: $CI_COMMIT_REF_SLUG
+    paths:
+      - node_modules/
+  script:
+    - yarn install --immutable
+    - yarn tsc --noEmit
+    - yarn lint
+    - yarn test --ci
+    - chmod +x android/gradlew
+    - cd android && ./gradlew assembleRelease && cd ..
+  artifacts:
+    paths:
+      - android/app/build/outputs/apk/**/*.apk
+    expire_in: 30 days
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+"
+`;
+
+exports[`Integration: Full Workflow Generation Pipeline GitLab CI — Static Analysis output structure matches snapshot 1`] = `
+"stages:
+  - static-analysis
+static-analysis:
+  image: node:20
+  stage: static-analysis
+  cache:
+    key: $CI_COMMIT_REF_SLUG
+    paths:
+      - node_modules/
+  script:
+    - yarn install --immutable
+    - yarn tsc --noEmit
+    - yarn lint
+    - yarn format:check
+    - yarn test --ci
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+"
 `;

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -576,4 +576,62 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
       ).toThrow();
     });
   });
+
+  // ─── GitLab CI ───────────────────────────────────────────────────────────
+
+  describe('GitLab CI — Static Analysis', () => {
+    it('generates valid parseable YAML with yarn', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: { platform: 'gitlab', packageManager: 'yarn', nodeVersions: [20] },
+      });
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      expect(parsed.stages).toContain('static-analysis');
+      expect(parsed['static-analysis'].image).toBe('node:20');
+    });
+
+    it('includes TypeScript check in script', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: { platform: 'gitlab', packageManager: 'yarn', nodeVersions: [18] },
+      });
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      const script: string[] = parsed['static-analysis'].script;
+      expect(script.some(s => s.includes('tsc'))).toBe(true);
+    });
+
+    it('output structure matches snapshot', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: { platform: 'gitlab', packageManager: 'yarn', nodeVersions: [20] },
+      });
+      expect(yamlStr).toMatchSnapshot();
+    });
+  });
+
+  describe('GitLab CI — Build (Android)', () => {
+    it('generates valid parseable YAML', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'build',
+        options: {
+          platform: 'gitlab',
+          build: { platform: 'android', variant: 'release', storage: 'github', notification: 'none' },
+        },
+      });
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      expect(parsed.stages).toContain('build');
+      expect(parsed.build.artifacts).toBeDefined();
+    });
+
+    it('output structure matches snapshot', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'build',
+        options: {
+          platform: 'gitlab',
+          build: { platform: 'android', variant: 'release', storage: 'github', notification: 'none' },
+        },
+      });
+      expect(yamlStr).toMatchSnapshot();
+    });
+  });
 });

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -583,7 +583,11 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
     it('generates valid parseable YAML with yarn', () => {
       const { yaml: yamlStr } = generateWorkflow({
         kind: 'static-analysis',
-        options: { platform: 'circleci', packageManager: 'yarn', nodeVersions: [20] },
+        options: {
+          platform: 'circleci',
+          packageManager: 'yarn',
+          nodeVersions: [20],
+        },
       });
       const parsed = yaml.load(yamlStr) as Record<string, any>;
       expect(parsed.version).toBeCloseTo(2.1);
@@ -593,13 +597,22 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
     it('includes TypeScript run step', () => {
       const { yaml: yamlStr } = generateWorkflow({
         kind: 'static-analysis',
-        options: { platform: 'circleci', packageManager: 'yarn', nodeVersions: [18] },
+        options: {
+          platform: 'circleci',
+          packageManager: 'yarn',
+          nodeVersions: [18],
+        },
       });
       const parsed = yaml.load(yamlStr) as Record<string, any>;
-      const steps: Array<string | Record<string, unknown>> = parsed.jobs['static-analysis'].steps;
-      const hasTs = steps.some(s =>
-        typeof s === 'object' && s !== null && 'run' in s &&
-        typeof (s as any).run === 'object' && ((s as any).run.command ?? '').includes('tsc')
+      const steps: Array<string | Record<string, unknown>> =
+        parsed.jobs['static-analysis'].steps;
+      const hasTs = steps.some(
+        s =>
+          typeof s === 'object' &&
+          s !== null &&
+          'run' in s &&
+          typeof (s as any).run === 'object' &&
+          ((s as any).run.command ?? '').includes('tsc')
       );
       expect(hasTs).toBe(true);
     });
@@ -607,7 +620,11 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
     it('output structure matches snapshot', () => {
       const { yaml: yamlStr } = generateWorkflow({
         kind: 'static-analysis',
-        options: { platform: 'circleci', packageManager: 'yarn', nodeVersions: [20] },
+        options: {
+          platform: 'circleci',
+          packageManager: 'yarn',
+          nodeVersions: [20],
+        },
       });
       expect(yamlStr).toMatchSnapshot();
     });
@@ -619,7 +636,12 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
         kind: 'build',
         options: {
           platform: 'circleci',
-          build: { platform: 'android', variant: 'release', storage: 'github', notification: 'none' },
+          build: {
+            platform: 'android',
+            variant: 'release',
+            storage: 'github',
+            notification: 'none',
+          },
         },
       });
       const parsed = yaml.load(yamlStr) as Record<string, any>;
@@ -632,7 +654,12 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
         kind: 'build',
         options: {
           platform: 'circleci',
-          build: { platform: 'android', variant: 'release', storage: 'github', notification: 'none' },
+          build: {
+            platform: 'android',
+            variant: 'release',
+            storage: 'github',
+            notification: 'none',
+          },
         },
       });
       expect(yamlStr).toMatchSnapshot();
@@ -645,7 +672,11 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
     it('generates valid parseable YAML with yarn', () => {
       const { yaml: yamlStr } = generateWorkflow({
         kind: 'static-analysis',
-        options: { platform: 'gitlab', packageManager: 'yarn', nodeVersions: [20] },
+        options: {
+          platform: 'gitlab',
+          packageManager: 'yarn',
+          nodeVersions: [20],
+        },
       });
       const parsed = yaml.load(yamlStr) as Record<string, any>;
       expect(parsed.stages).toContain('static-analysis');
@@ -655,7 +686,11 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
     it('includes TypeScript check in script', () => {
       const { yaml: yamlStr } = generateWorkflow({
         kind: 'static-analysis',
-        options: { platform: 'gitlab', packageManager: 'yarn', nodeVersions: [18] },
+        options: {
+          platform: 'gitlab',
+          packageManager: 'yarn',
+          nodeVersions: [18],
+        },
       });
       const parsed = yaml.load(yamlStr) as Record<string, any>;
       const script: string[] = parsed['static-analysis'].script;
@@ -665,7 +700,11 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
     it('output structure matches snapshot', () => {
       const { yaml: yamlStr } = generateWorkflow({
         kind: 'static-analysis',
-        options: { platform: 'gitlab', packageManager: 'yarn', nodeVersions: [20] },
+        options: {
+          platform: 'gitlab',
+          packageManager: 'yarn',
+          nodeVersions: [20],
+        },
       });
       expect(yamlStr).toMatchSnapshot();
     });
@@ -677,7 +716,12 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
         kind: 'build',
         options: {
           platform: 'gitlab',
-          build: { platform: 'android', variant: 'release', storage: 'github', notification: 'none' },
+          build: {
+            platform: 'android',
+            variant: 'release',
+            storage: 'github',
+            notification: 'none',
+          },
         },
       });
       const parsed = yaml.load(yamlStr) as Record<string, any>;
@@ -690,7 +734,12 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
         kind: 'build',
         options: {
           platform: 'gitlab',
-          build: { platform: 'android', variant: 'release', storage: 'github', notification: 'none' },
+          build: {
+            platform: 'android',
+            variant: 'release',
+            storage: 'github',
+            notification: 'none',
+          },
         },
       });
       expect(yamlStr).toMatchSnapshot();

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -577,6 +577,68 @@ describe('Integration: Full Workflow Generation Pipeline', () => {
     });
   });
 
+  // ─── CircleCI ────────────────────────────────────────────────────────────
+
+  describe('CircleCI — Static Analysis', () => {
+    it('generates valid parseable YAML with yarn', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: { platform: 'circleci', packageManager: 'yarn', nodeVersions: [20] },
+      });
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      expect(parsed.version).toBeCloseTo(2.1);
+      expect(parsed.jobs['static-analysis']).toBeDefined();
+    });
+
+    it('includes TypeScript run step', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: { platform: 'circleci', packageManager: 'yarn', nodeVersions: [18] },
+      });
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      const steps: Array<string | Record<string, unknown>> = parsed.jobs['static-analysis'].steps;
+      const hasTs = steps.some(s =>
+        typeof s === 'object' && s !== null && 'run' in s &&
+        typeof (s as any).run === 'object' && ((s as any).run.command ?? '').includes('tsc')
+      );
+      expect(hasTs).toBe(true);
+    });
+
+    it('output structure matches snapshot', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'static-analysis',
+        options: { platform: 'circleci', packageManager: 'yarn', nodeVersions: [20] },
+      });
+      expect(yamlStr).toMatchSnapshot();
+    });
+  });
+
+  describe('CircleCI — Build (Android)', () => {
+    it('generates valid parseable YAML', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'build',
+        options: {
+          platform: 'circleci',
+          build: { platform: 'android', variant: 'release', storage: 'github', notification: 'none' },
+        },
+      });
+      const parsed = yaml.load(yamlStr) as Record<string, any>;
+      expect(parsed.version).toBeCloseTo(2.1);
+      expect(parsed.jobs.build).toBeDefined();
+    });
+
+    it('output structure matches snapshot', () => {
+      const { yaml: yamlStr } = generateWorkflow({
+        kind: 'build',
+        options: {
+          platform: 'circleci',
+          build: { platform: 'android', variant: 'release', storage: 'github', notification: 'none' },
+        },
+      });
+      expect(yamlStr).toMatchSnapshot();
+    });
+  });
+
   // ─── GitLab CI ───────────────────────────────────────────────────────────
 
   describe('GitLab CI — Static Analysis', () => {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -224,12 +224,18 @@ export function writeWorkflowFile(
   let outputFileName = fileName;
 
   if (!outputDir) {
-    outputDir = platform === 'bitrise' ? '.' : '.github/workflows';
+    if (platform === 'bitrise' || platform === 'gitlab') {
+      outputDir = '.';
+    } else {
+      outputDir = '.github/workflows';
+    }
   }
 
   if (!outputFileName) {
     if (platform === 'bitrise') {
       outputFileName = 'bitrise.yml';
+    } else if (platform === 'gitlab') {
+      outputFileName = '.gitlab-ci.yml';
     } else {
       outputFileName = `${cfg.kind}.yaml`;
     }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -226,6 +226,8 @@ export function writeWorkflowFile(
   if (!outputDir) {
     if (platform === 'bitrise' || platform === 'gitlab') {
       outputDir = '.';
+    } else if (platform === 'circleci') {
+      outputDir = '.circleci';
     } else {
       outputDir = '.github/workflows';
     }
@@ -236,6 +238,8 @@ export function writeWorkflowFile(
       outputFileName = 'bitrise.yml';
     } else if (platform === 'gitlab') {
       outputFileName = '.gitlab-ci.yml';
+    } else if (platform === 'circleci') {
+      outputFileName = 'config.yml';
     } else {
       outputFileName = `${cfg.kind}.yaml`;
     }

--- a/src/presets/__tests__/__snapshots__/circleciBuilPreset.test.ts.snap
+++ b/src/presets/__tests__/__snapshots__/circleciBuilPreset.test.ts.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildCircleCIBuildPipeline output matches snapshot for default options 1`] = `
+{
+  "jobs": {
+    "build": {
+      "docker": [
+        {
+          "image": "cimg/android:2024.01",
+        },
+      ],
+      "environment": {
+        "NODE_VERSION": "20",
+      },
+      "steps": [
+        "checkout",
+        {
+          "node/install-packages": {
+            "pkg-manager": "yarn",
+          },
+        },
+        {
+          "run": {
+            "command": "chmod +x android/gradlew",
+            "name": "Make gradlew executable",
+          },
+        },
+        {
+          "run": {
+            "command": "cd android && ./gradlew assembleRelease && cd ..",
+            "name": "Build Android",
+            "no_output_timeout": "30m",
+          },
+        },
+        {
+          "store_artifacts": {
+            "path": "android/app/build/outputs/apk",
+          },
+        },
+      ],
+    },
+  },
+  "orbs": {
+    "node": "circleci/node@5",
+  },
+  "version": 2.1,
+  "workflows": {
+    "build": {
+      "jobs": [
+        {
+          "build": {},
+        },
+      ],
+    },
+  },
+}
+`;

--- a/src/presets/__tests__/__snapshots__/circleciStaticAnalysis.test.ts.snap
+++ b/src/presets/__tests__/__snapshots__/circleciStaticAnalysis.test.ts.snap
@@ -1,0 +1,119 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildCircleCIStaticAnalysisPipeline output matches snapshot for default options 1`] = `
+{
+  "jobs": {
+    "static-analysis": {
+      "docker": [
+        {
+          "image": "cimg/node:20.0",
+        },
+      ],
+      "steps": [
+        "checkout",
+        {
+          "node/install-packages": {
+            "pkg-manager": "yarn",
+          },
+        },
+        {
+          "run": {
+            "command": "yarn tsc --noEmit",
+            "name": "TypeScript",
+          },
+        },
+        {
+          "run": {
+            "command": "yarn lint",
+            "name": "ESLint",
+          },
+        },
+        {
+          "run": {
+            "command": "yarn format:check",
+            "name": "Prettier",
+          },
+        },
+        {
+          "run": {
+            "command": "yarn test --ci",
+            "name": "Unit Tests",
+          },
+        },
+      ],
+    },
+  },
+  "orbs": {
+    "node": "circleci/node@5",
+  },
+  "version": 2.1,
+  "workflows": {
+    "static-analysis": {
+      "jobs": [
+        {
+          "static-analysis": {},
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`buildCircleCIStaticAnalysisPipeline output matches snapshot for npm package manager 1`] = `
+{
+  "jobs": {
+    "static-analysis": {
+      "docker": [
+        {
+          "image": "cimg/node:20.0",
+        },
+      ],
+      "steps": [
+        "checkout",
+        {
+          "node/install-packages": {
+            "pkg-manager": "npm",
+          },
+        },
+        {
+          "run": {
+            "command": "npm run tsc -- --noEmit",
+            "name": "TypeScript",
+          },
+        },
+        {
+          "run": {
+            "command": "npm run lint",
+            "name": "ESLint",
+          },
+        },
+        {
+          "run": {
+            "command": "npm run format:check",
+            "name": "Prettier",
+          },
+        },
+        {
+          "run": {
+            "command": "npm test -- --ci",
+            "name": "Unit Tests",
+          },
+        },
+      ],
+    },
+  },
+  "orbs": {
+    "node": "circleci/node@5",
+  },
+  "version": 2.1,
+  "workflows": {
+    "static-analysis": {
+      "jobs": [
+        {
+          "static-analysis": {},
+        },
+      ],
+    },
+  },
+}
+`;

--- a/src/presets/__tests__/circleciBuilPreset.test.ts
+++ b/src/presets/__tests__/circleciBuilPreset.test.ts
@@ -1,0 +1,108 @@
+import { buildCircleCIBuildPipeline } from '../circleciBuilPreset';
+import { WorkflowOptions } from '../../types';
+
+describe('buildCircleCIBuildPipeline', () => {
+  const defaultOptions: WorkflowOptions = {
+    platform: 'circleci',
+    packageManager: 'yarn',
+    build: {
+      platform: 'android',
+      variant: 'release',
+      androidOutputType: 'apk',
+      storage: 'github',
+      notification: 'none',
+      includeStaticAnalysis: false,
+    },
+  };
+
+  describe('output structure', () => {
+    it('returns version 2.1', () => {
+      const result = buildCircleCIBuildPipeline(defaultOptions);
+
+      expect(result.version).toBe(2.1);
+    });
+
+    it('defines a build job', () => {
+      const result = buildCircleCIBuildPipeline(defaultOptions);
+      const jobs = result.jobs as Record<string, unknown>;
+
+      expect(jobs['build']).toBeDefined();
+    });
+
+    it('uses the Android Docker image', () => {
+      const result = buildCircleCIBuildPipeline(defaultOptions);
+      const jobs = result.jobs as Record<string, unknown>;
+      const job = jobs['build'] as Record<string, unknown>;
+      const docker = job.docker as Array<Record<string, string>>;
+
+      expect(docker[0].image).toBe('cimg/android:2024.01');
+    });
+
+    it('includes a store_artifacts step', () => {
+      const result = buildCircleCIBuildPipeline(defaultOptions);
+      const jobs = result.jobs as Record<string, unknown>;
+      const job = jobs['build'] as Record<string, unknown>;
+      const steps = job.steps as Array<string | Record<string, unknown>>;
+      const artifactStep = steps.find(
+        s => typeof s === 'object' && 'store_artifacts' in s
+      );
+
+      expect(artifactStep).toBeDefined();
+    });
+  });
+
+  describe('build commands', () => {
+    it('includes assembleRelease for release APK build', () => {
+      const result = buildCircleCIBuildPipeline(defaultOptions);
+      const jobs = result.jobs as Record<string, unknown>;
+      const job = jobs['build'] as Record<string, unknown>;
+      const steps = job.steps as Array<string | Record<string, unknown>>;
+      const buildStep = steps.find(
+        s =>
+          typeof s === 'object' &&
+          'run' in s &&
+          (s.run as Record<string, string>).name === 'Build Android'
+      ) as Record<string, unknown> | undefined;
+      const cmd = (buildStep?.run as Record<string, string>)?.command;
+
+      expect(cmd).toContain('assembleRelease');
+    });
+
+    it('includes bundleRelease for AAB build', () => {
+      const result = buildCircleCIBuildPipeline({
+        ...defaultOptions,
+        build: { ...defaultOptions.build, androidOutputType: 'aab' },
+      });
+      const jobs = result.jobs as Record<string, unknown>;
+      const job = jobs['build'] as Record<string, unknown>;
+      const steps = job.steps as Array<string | Record<string, unknown>>;
+      const buildStep = steps.find(
+        s =>
+          typeof s === 'object' &&
+          'run' in s &&
+          (s.run as Record<string, string>).name === 'Build Android'
+      ) as Record<string, unknown> | undefined;
+      const cmd = (buildStep?.run as Record<string, string>)?.command;
+
+      expect(cmd).toContain('bundleRelease');
+    });
+  });
+
+  describe('notifications', () => {
+    it('adds slack orb when notification is slack', () => {
+      const result = buildCircleCIBuildPipeline({
+        ...defaultOptions,
+        build: { ...defaultOptions.build, notification: 'slack' },
+      });
+      const orbs = result.orbs as Record<string, string>;
+
+      expect(orbs.slack).toBeDefined();
+    });
+  });
+
+  it('output matches snapshot for default options', () => {
+    const result = buildCircleCIBuildPipeline(defaultOptions);
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/src/presets/__tests__/circleciStaticAnalysis.test.ts
+++ b/src/presets/__tests__/circleciStaticAnalysis.test.ts
@@ -68,7 +68,10 @@ describe('buildCircleCIStaticAnalysisPipeline', () => {
       ) as Record<string, unknown> | undefined;
 
       expect(installStep).toBeDefined();
-      const installConfig = installStep!['node/install-packages'] as Record<string, string>;
+      const installConfig = installStep!['node/install-packages'] as Record<
+        string,
+        string
+      >;
       expect(installConfig['pkg-manager']).toBe('yarn');
     });
 
@@ -83,7 +86,10 @@ describe('buildCircleCIStaticAnalysisPipeline', () => {
       const installStep = steps.find(
         s => typeof s === 'object' && 'node/install-packages' in s
       ) as Record<string, unknown> | undefined;
-      const installConfig = installStep!['node/install-packages'] as Record<string, string>;
+      const installConfig = installStep!['node/install-packages'] as Record<
+        string,
+        string
+      >;
 
       expect(installConfig['pkg-manager']).toBe('npm');
     });

--- a/src/presets/__tests__/circleciStaticAnalysis.test.ts
+++ b/src/presets/__tests__/circleciStaticAnalysis.test.ts
@@ -1,0 +1,178 @@
+import { buildCircleCIStaticAnalysisPipeline } from '../circleciStaticAnalysis';
+import { WorkflowOptions } from '../../types';
+
+describe('buildCircleCIStaticAnalysisPipeline', () => {
+  const defaultOptions: WorkflowOptions = {
+    platform: 'circleci',
+    packageManager: 'yarn',
+  };
+
+  describe('output structure', () => {
+    it('returns version 2.1', () => {
+      const result = buildCircleCIStaticAnalysisPipeline(defaultOptions);
+
+      expect(result.version).toBe(2.1);
+    });
+
+    it('includes the circleci/node orb', () => {
+      const result = buildCircleCIStaticAnalysisPipeline(defaultOptions);
+      const orbs = result.orbs as Record<string, string>;
+
+      expect(orbs.node).toBe('circleci/node@5');
+    });
+
+    it('defines a static-analysis job', () => {
+      const result = buildCircleCIStaticAnalysisPipeline(defaultOptions);
+      const jobs = result.jobs as Record<string, unknown>;
+
+      expect(jobs['static-analysis']).toBeDefined();
+    });
+
+    it('uses the correct Docker image', () => {
+      const result = buildCircleCIStaticAnalysisPipeline({
+        ...defaultOptions,
+        nodeVersions: [20],
+      });
+      const jobs = result.jobs as Record<string, unknown>;
+      const job = jobs['static-analysis'] as Record<string, unknown>;
+      const docker = job.docker as Array<Record<string, string>>;
+
+      expect(docker[0].image).toBe('cimg/node:20.0');
+    });
+
+    it('defines a static-analysis workflow', () => {
+      const result = buildCircleCIStaticAnalysisPipeline(defaultOptions);
+      const workflows = result.workflows as Record<string, unknown>;
+
+      expect(workflows['static-analysis']).toBeDefined();
+    });
+  });
+
+  describe('steps', () => {
+    it('starts with checkout', () => {
+      const result = buildCircleCIStaticAnalysisPipeline(defaultOptions);
+      const jobs = result.jobs as Record<string, unknown>;
+      const job = jobs['static-analysis'] as Record<string, unknown>;
+      const steps = job.steps as Array<string | Record<string, unknown>>;
+
+      expect(steps[0]).toBe('checkout');
+    });
+
+    it('uses node/install-packages step', () => {
+      const result = buildCircleCIStaticAnalysisPipeline(defaultOptions);
+      const jobs = result.jobs as Record<string, unknown>;
+      const job = jobs['static-analysis'] as Record<string, unknown>;
+      const steps = job.steps as Array<string | Record<string, unknown>>;
+      const installStep = steps.find(
+        s => typeof s === 'object' && 'node/install-packages' in s
+      ) as Record<string, unknown> | undefined;
+
+      expect(installStep).toBeDefined();
+      const installConfig = installStep!['node/install-packages'] as Record<string, string>;
+      expect(installConfig['pkg-manager']).toBe('yarn');
+    });
+
+    it('uses npm as pkg-manager for npm projects', () => {
+      const result = buildCircleCIStaticAnalysisPipeline({
+        ...defaultOptions,
+        packageManager: 'npm',
+      });
+      const jobs = result.jobs as Record<string, unknown>;
+      const job = jobs['static-analysis'] as Record<string, unknown>;
+      const steps = job.steps as Array<string | Record<string, unknown>>;
+      const installStep = steps.find(
+        s => typeof s === 'object' && 'node/install-packages' in s
+      ) as Record<string, unknown> | undefined;
+      const installConfig = installStep!['node/install-packages'] as Record<string, string>;
+
+      expect(installConfig['pkg-manager']).toBe('npm');
+    });
+
+    it('includes TypeScript run step by default', () => {
+      const result = buildCircleCIStaticAnalysisPipeline(defaultOptions);
+      const jobs = result.jobs as Record<string, unknown>;
+      const job = jobs['static-analysis'] as Record<string, unknown>;
+      const steps = job.steps as Array<string | Record<string, unknown>>;
+      const tsStep = steps.find(
+        s =>
+          typeof s === 'object' &&
+          'run' in s &&
+          (s.run as Record<string, string>).name === 'TypeScript'
+      );
+
+      expect(tsStep).toBeDefined();
+    });
+
+    it('excludes TypeScript step when disabled', () => {
+      const result = buildCircleCIStaticAnalysisPipeline({
+        ...defaultOptions,
+        staticAnalysis: { typescript: false },
+      });
+      const jobs = result.jobs as Record<string, unknown>;
+      const job = jobs['static-analysis'] as Record<string, unknown>;
+      const steps = job.steps as Array<string | Record<string, unknown>>;
+      const tsStep = steps.find(
+        s =>
+          typeof s === 'object' &&
+          'run' in s &&
+          (s.run as Record<string, string>).name === 'TypeScript'
+      );
+
+      expect(tsStep).toBeUndefined();
+    });
+  });
+
+  describe('notifications', () => {
+    it('adds circleci/slack orb when notification is slack', () => {
+      const result = buildCircleCIStaticAnalysisPipeline({
+        ...defaultOptions,
+        staticAnalysis: { notification: 'slack' },
+      });
+      const orbs = result.orbs as Record<string, string>;
+
+      expect(orbs.slack).toBeDefined();
+    });
+
+    it('does not add slack orb when notification is none', () => {
+      const result = buildCircleCIStaticAnalysisPipeline({
+        ...defaultOptions,
+        staticAnalysis: { notification: 'none' },
+      });
+      const orbs = result.orbs as Record<string, string>;
+
+      expect(orbs.slack).toBeUndefined();
+    });
+  });
+
+  describe('triggers', () => {
+    it('applies branch filters when push branches are configured', () => {
+      const result = buildCircleCIStaticAnalysisPipeline({
+        ...defaultOptions,
+        triggers: { push: { branches: ['main', 'develop'] } },
+      });
+      const workflows = result.workflows as Record<string, unknown>;
+      const workflow = workflows['static-analysis'] as Record<string, unknown>;
+      const jobs = workflow.jobs as Array<Record<string, unknown>>;
+      const jobEntry = jobs[0]['static-analysis'] as Record<string, unknown>;
+      const filters = jobEntry.filters as Record<string, unknown>;
+      const branches = filters?.branches as Record<string, unknown>;
+
+      expect(branches?.only).toEqual(['main', 'develop']);
+    });
+  });
+
+  it('output matches snapshot for default options', () => {
+    const result = buildCircleCIStaticAnalysisPipeline(defaultOptions);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('output matches snapshot for npm package manager', () => {
+    const result = buildCircleCIStaticAnalysisPipeline({
+      ...defaultOptions,
+      packageManager: 'npm',
+    });
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/src/presets/__tests__/gitlabBuildPreset.test.ts
+++ b/src/presets/__tests__/gitlabBuildPreset.test.ts
@@ -1,0 +1,137 @@
+import { buildGitlabBuildPipeline } from '../gitlabBuildPreset';
+import { WorkflowOptions } from '../../types';
+
+describe('buildGitlabBuildPipeline', () => {
+  const defaultOptions: WorkflowOptions = {
+    platform: 'gitlab',
+    packageManager: 'yarn',
+    build: {
+      platform: 'android',
+      variant: 'release',
+      androidOutputType: 'apk',
+      storage: 'github',
+      notification: 'none',
+      includeStaticAnalysis: false,
+    },
+  };
+
+  describe('output structure', () => {
+    it('returns stages and build job', () => {
+      const result = buildGitlabBuildPipeline(defaultOptions);
+
+      expect(result.stages).toEqual(['build']);
+      expect(result['build']).toBeDefined();
+    });
+
+    it('uses the correct node Docker image', () => {
+      const result = buildGitlabBuildPipeline({
+        ...defaultOptions,
+        nodeVersions: [20],
+      });
+      const job = result['build'] as Record<string, unknown>;
+
+      expect(job.image).toBe('node:20');
+    });
+
+    it('includes artifacts section', () => {
+      const result = buildGitlabBuildPipeline(defaultOptions);
+      const job = result['build'] as Record<string, unknown>;
+
+      expect(job.artifacts).toBeDefined();
+    });
+
+    it('sets artifact expire_in to 30 days', () => {
+      const result = buildGitlabBuildPipeline(defaultOptions);
+      const job = result['build'] as Record<string, unknown>;
+      const artifacts = job.artifacts as Record<string, unknown>;
+
+      expect(artifacts.expire_in).toBe('30 days');
+    });
+  });
+
+  describe('build commands', () => {
+    it('includes assembleRelease for release APK build', () => {
+      const result = buildGitlabBuildPipeline(defaultOptions);
+      const job = result['build'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('assembleRelease'))).toBe(true);
+    });
+
+    it('includes assembleDebug for debug build', () => {
+      const result = buildGitlabBuildPipeline({
+        ...defaultOptions,
+        build: { ...defaultOptions.build, variant: 'debug' },
+      });
+      const job = result['build'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('assembleDebug'))).toBe(true);
+    });
+
+    it('includes bundleRelease for AAB output', () => {
+      const result = buildGitlabBuildPipeline({
+        ...defaultOptions,
+        build: { ...defaultOptions.build, androidOutputType: 'aab' },
+      });
+      const job = result['build'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('bundleRelease'))).toBe(true);
+    });
+
+    it('includes both assemble and bundle tasks for both output', () => {
+      const result = buildGitlabBuildPipeline({
+        ...defaultOptions,
+        build: { ...defaultOptions.build, androidOutputType: 'both' },
+      });
+      const job = result['build'] as Record<string, unknown>;
+      const script = job.script as string[];
+      const buildCmd = script.find(s => s.includes('assembleRelease') || s.includes('assembleDebug')) ?? '';
+
+      expect(buildCmd).toContain('assembleRelease');
+      expect(buildCmd).toContain('bundleRelease');
+    });
+  });
+
+  describe('static analysis', () => {
+    it('includes TypeScript check when includeStaticAnalysis is true', () => {
+      const result = buildGitlabBuildPipeline({
+        ...defaultOptions,
+        build: { ...defaultOptions.build, includeStaticAnalysis: true },
+      });
+      const job = result['build'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('tsc'))).toBe(true);
+    });
+
+    it('excludes TypeScript check when includeStaticAnalysis is false', () => {
+      const result = buildGitlabBuildPipeline(defaultOptions);
+      const job = result['build'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('tsc'))).toBe(false);
+    });
+  });
+
+  describe('notifications', () => {
+    it('adds Slack after_script when notification is slack', () => {
+      const result = buildGitlabBuildPipeline({
+        ...defaultOptions,
+        build: { ...defaultOptions.build, notification: 'slack' },
+      });
+      const job = result['build'] as Record<string, unknown>;
+
+      expect(job.after_script).toBeDefined();
+      const afterScript = job.after_script as string[];
+      expect(afterScript.some(s => s.includes('SLACK_WEBHOOK_URL'))).toBe(true);
+    });
+  });
+
+  it('output matches snapshot for default options', () => {
+    const result = buildGitlabBuildPipeline(defaultOptions);
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/src/presets/__tests__/gitlabStaticAnalysis.test.ts
+++ b/src/presets/__tests__/gitlabStaticAnalysis.test.ts
@@ -1,0 +1,178 @@
+import { buildGitlabStaticAnalysisPipeline } from '../gitlabStaticAnalysis';
+import { WorkflowOptions } from '../../types';
+
+describe('buildGitlabStaticAnalysisPipeline', () => {
+  const defaultOptions: WorkflowOptions = {
+    platform: 'gitlab',
+    packageManager: 'yarn',
+  };
+
+  describe('output structure', () => {
+    it('returns stages and static-analysis job', () => {
+      const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+
+      expect(result.stages).toEqual(['static-analysis']);
+      expect(result['static-analysis']).toBeDefined();
+    });
+
+    it('uses the correct node Docker image', () => {
+      const result = buildGitlabStaticAnalysisPipeline({
+        ...defaultOptions,
+        nodeVersions: [20],
+      });
+      const job = result['static-analysis'] as Record<string, unknown>;
+
+      expect(job.image).toBe('node:20');
+    });
+
+    it('uses a custom node version', () => {
+      const result = buildGitlabStaticAnalysisPipeline({
+        ...defaultOptions,
+        nodeVersions: [18],
+      });
+      const job = result['static-analysis'] as Record<string, unknown>;
+
+      expect(job.image).toBe('node:18');
+    });
+
+    it('includes cache configuration', () => {
+      const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+      const job = result['static-analysis'] as Record<string, unknown>;
+
+      expect(job.cache).toBeDefined();
+    });
+
+    it('includes rules', () => {
+      const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+      const job = result['static-analysis'] as Record<string, unknown>;
+
+      expect(Array.isArray(job.rules)).toBe(true);
+      expect((job.rules as unknown[]).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('scripts', () => {
+    it('uses yarn install --immutable for yarn', () => {
+      const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+      const job = result['static-analysis'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script[0]).toBe('yarn install --immutable');
+    });
+
+    it('uses npm ci for npm', () => {
+      const result = buildGitlabStaticAnalysisPipeline({
+        ...defaultOptions,
+        packageManager: 'npm',
+      });
+      const job = result['static-analysis'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script[0]).toBe('npm ci');
+    });
+
+    it('includes TypeScript check by default', () => {
+      const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+      const job = result['static-analysis'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('tsc'))).toBe(true);
+    });
+
+    it('excludes TypeScript check when disabled', () => {
+      const result = buildGitlabStaticAnalysisPipeline({
+        ...defaultOptions,
+        staticAnalysis: { typescript: false },
+      });
+      const job = result['static-analysis'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('tsc'))).toBe(false);
+    });
+
+    it('includes ESLint by default', () => {
+      const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+      const job = result['static-analysis'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('lint'))).toBe(true);
+    });
+
+    it('includes Prettier by default', () => {
+      const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+      const job = result['static-analysis'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('format:check'))).toBe(true);
+    });
+
+    it('includes unit tests by default', () => {
+      const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+      const job = result['static-analysis'] as Record<string, unknown>;
+      const script = job.script as string[];
+
+      expect(script.some(s => s.includes('test'))).toBe(true);
+    });
+  });
+
+  describe('triggers', () => {
+    it('defaults to push and MR rules when no triggers configured', () => {
+      const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+      const job = result['static-analysis'] as Record<string, unknown>;
+      const rules = job.rules as Array<Record<string, string>>;
+
+      expect(rules.some(r => r.if?.includes('push'))).toBe(true);
+      expect(rules.some(r => r.if?.includes('merge_request'))).toBe(true);
+    });
+
+    it('uses custom push branches when provided', () => {
+      const result = buildGitlabStaticAnalysisPipeline({
+        ...defaultOptions,
+        triggers: { push: { branches: ['develop'] } },
+      });
+      const job = result['static-analysis'] as Record<string, unknown>;
+      const rules = job.rules as Array<Record<string, string>>;
+
+      expect(rules.some(r => r.if?.includes('develop'))).toBe(true);
+    });
+  });
+
+  describe('notifications', () => {
+    it('adds after_script for Slack notification', () => {
+      const result = buildGitlabStaticAnalysisPipeline({
+        ...defaultOptions,
+        staticAnalysis: { notification: 'slack' },
+      });
+      const job = result['static-analysis'] as Record<string, unknown>;
+
+      expect(job.after_script).toBeDefined();
+      const afterScript = job.after_script as string[];
+      expect(afterScript.some(s => s.includes('SLACK_WEBHOOK_URL'))).toBe(true);
+    });
+
+    it('does not add after_script when notification is none', () => {
+      const result = buildGitlabStaticAnalysisPipeline({
+        ...defaultOptions,
+        staticAnalysis: { notification: 'none' },
+      });
+      const job = result['static-analysis'] as Record<string, unknown>;
+
+      expect(job.after_script).toBeUndefined();
+    });
+  });
+
+  it('output matches snapshot for default options', () => {
+    const result = buildGitlabStaticAnalysisPipeline(defaultOptions);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('output matches snapshot for npm package manager', () => {
+    const result = buildGitlabStaticAnalysisPipeline({
+      ...defaultOptions,
+      packageManager: 'npm',
+    });
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/src/presets/circleciBuilPreset.ts
+++ b/src/presets/circleciBuilPreset.ts
@@ -46,8 +46,7 @@ export function buildCircleCIBuildPipeline(
     steps.push({
       run: {
         name: 'ESLint',
-        command:
-          packageManager === 'yarn' ? 'yarn lint' : 'npm run lint',
+        command: packageManager === 'yarn' ? 'yarn lint' : 'npm run lint',
       },
     });
     steps.push({
@@ -88,8 +87,7 @@ export function buildCircleCIBuildPipeline(
     let gradleTask: string;
 
     if (outputType === 'both') {
-      const apkTask =
-        variant === 'debug' ? 'assembleDebug' : 'assembleRelease';
+      const apkTask = variant === 'debug' ? 'assembleDebug' : 'assembleRelease';
       const aabTask = variant === 'debug' ? 'bundleDebug' : 'bundleRelease';
       gradleTask = `${apkTask} ${aabTask}`;
     } else if (outputType === 'aab') {
@@ -102,7 +100,7 @@ export function buildCircleCIBuildPipeline(
       run: {
         name: 'Build Android',
         command: `cd android && ./gradlew ${gradleTask} && cd ..`,
-        'no_output_timeout': '30m',
+        no_output_timeout: '30m',
       },
     });
   }
@@ -129,10 +127,7 @@ export function buildCircleCIBuildPipeline(
 
   // Slack notification
   const orbs: Record<string, string> = { node: 'circleci/node@5' };
-  if (
-    buildOpts.notification === 'slack' ||
-    buildOpts.notification === 'both'
-  ) {
+  if (buildOpts.notification === 'slack' || buildOpts.notification === 'both') {
     orbs.slack = 'circleci/slack@4';
     steps.push({
       'slack/notify': {

--- a/src/presets/circleciBuilPreset.ts
+++ b/src/presets/circleciBuilPreset.ts
@@ -1,0 +1,173 @@
+import { WorkflowOptions } from '../types';
+import { BuildOptions } from './types';
+
+export function buildCircleCIBuildPipeline(
+  opts: WorkflowOptions
+): Record<string, unknown> {
+  const {
+    triggers,
+    nodeVersions = [20],
+    packageManager = 'yarn',
+    framework = 'react-native-cli',
+    build = {
+      platform: 'android',
+      variant: 'release',
+      androidOutputType: 'apk',
+      storage: 'github',
+      notification: 'none',
+      includeStaticAnalysis: false,
+    },
+  } = opts;
+
+  const nodeVersion = nodeVersions[0] ?? 20;
+  const buildOpts = build as BuildOptions;
+
+  // Build job steps
+  const steps: Array<string | Record<string, unknown>> = ['checkout'];
+
+  // Install dependencies
+  steps.push({
+    'node/install-packages': {
+      'pkg-manager': packageManager,
+    },
+  });
+
+  // Static analysis steps
+  if (buildOpts.includeStaticAnalysis) {
+    steps.push({
+      run: {
+        name: 'TypeScript',
+        command:
+          packageManager === 'yarn'
+            ? 'yarn tsc --noEmit'
+            : 'npm run tsc -- --noEmit',
+      },
+    });
+    steps.push({
+      run: {
+        name: 'ESLint',
+        command:
+          packageManager === 'yarn' ? 'yarn lint' : 'npm run lint',
+      },
+    });
+    steps.push({
+      run: {
+        name: 'Unit Tests',
+        command:
+          packageManager === 'yarn' ? 'yarn test --ci' : 'npm test -- --ci',
+      },
+    });
+  }
+
+  // Build step
+  if (framework === 'expo') {
+    steps.push({
+      run: {
+        name: 'Install EAS CLI',
+        command: 'npm install -g eas-cli',
+      },
+    });
+    const outputFlag =
+      buildOpts.androidOutputType === 'aab' ? 'production' : 'production-apk';
+    steps.push({
+      run: {
+        name: 'Build Android',
+        command: `eas build --platform android --profile ${outputFlag} --local --non-interactive`,
+      },
+    });
+  } else {
+    steps.push({
+      run: {
+        name: 'Make gradlew executable',
+        command: 'chmod +x android/gradlew',
+      },
+    });
+
+    const variant = buildOpts.variant ?? 'release';
+    const outputType = buildOpts.androidOutputType ?? 'apk';
+    let gradleTask: string;
+
+    if (outputType === 'both') {
+      const apkTask =
+        variant === 'debug' ? 'assembleDebug' : 'assembleRelease';
+      const aabTask = variant === 'debug' ? 'bundleDebug' : 'bundleRelease';
+      gradleTask = `${apkTask} ${aabTask}`;
+    } else if (outputType === 'aab') {
+      gradleTask = variant === 'debug' ? 'bundleDebug' : 'bundleRelease';
+    } else {
+      gradleTask = variant === 'debug' ? 'assembleDebug' : 'assembleRelease';
+    }
+
+    steps.push({
+      run: {
+        name: 'Build Android',
+        command: `cd android && ./gradlew ${gradleTask} && cd ..`,
+        'no_output_timeout': '30m',
+      },
+    });
+  }
+
+  // Store artifacts
+  const artifactPaths: string[] = [];
+  const outputType = buildOpts.androidOutputType ?? 'apk';
+  if (framework === 'expo') {
+    artifactPaths.push('expo-builds/');
+  } else {
+    if (outputType === 'apk' || outputType === 'both') {
+      artifactPaths.push('android/app/build/outputs/apk');
+    }
+    if (outputType === 'aab' || outputType === 'both') {
+      artifactPaths.push('android/app/build/outputs/bundle');
+    }
+  }
+
+  steps.push({
+    store_artifacts: {
+      path: artifactPaths.length === 1 ? artifactPaths[0] : artifactPaths,
+    },
+  });
+
+  // Slack notification
+  const orbs: Record<string, string> = { node: 'circleci/node@5' };
+  if (
+    buildOpts.notification === 'slack' ||
+    buildOpts.notification === 'both'
+  ) {
+    orbs.slack = 'circleci/slack@4';
+    steps.push({
+      'slack/notify': {
+        event: 'always',
+        template: 'basic_success_1',
+      },
+    });
+  }
+
+  // Branch filters
+  const branchFilter: Record<string, unknown> = {};
+  if (triggers?.push?.branches && triggers.push.branches.length > 0) {
+    branchFilter.only = triggers.push.branches;
+  }
+  const jobFilters =
+    Object.keys(branchFilter).length > 0
+      ? { filters: { branches: branchFilter } }
+      : {};
+
+  return {
+    version: 2.1,
+    orbs,
+    jobs: {
+      build: {
+        docker: [{ image: `cimg/android:2024.01` }],
+        environment: {
+          NODE_VERSION: String(nodeVersion),
+        },
+        steps,
+      },
+    },
+    workflows: {
+      build: {
+        jobs: [{ build: jobFilters }],
+      },
+    },
+  };
+}

--- a/src/presets/circleciStaticAnalysis.ts
+++ b/src/presets/circleciStaticAnalysis.ts
@@ -43,8 +43,7 @@ export function buildCircleCIStaticAnalysisPipeline(
     steps.push({
       run: {
         name: 'ESLint',
-        command:
-          packageManager === 'yarn' ? 'yarn lint' : 'npm run lint',
+        command: packageManager === 'yarn' ? 'yarn lint' : 'npm run lint',
       },
     });
   }

--- a/src/presets/circleciStaticAnalysis.ts
+++ b/src/presets/circleciStaticAnalysis.ts
@@ -1,0 +1,124 @@
+import { WorkflowOptions } from '../types';
+
+export function buildCircleCIStaticAnalysisPipeline(
+  opts: WorkflowOptions
+): Record<string, unknown> {
+  const {
+    triggers,
+    nodeVersions = [20],
+    packageManager = 'yarn',
+    staticAnalysis = {
+      typescript: true,
+      eslint: true,
+      prettier: true,
+      unitTests: true,
+    },
+  } = opts;
+
+  const nodeVersion = nodeVersions[0] ?? 20;
+
+  // Build job steps
+  const steps: Array<string | Record<string, unknown>> = ['checkout'];
+
+  // Install dependencies using the node orb
+  steps.push({
+    'node/install-packages': {
+      'pkg-manager': packageManager,
+    },
+  });
+
+  if (staticAnalysis.typescript !== false) {
+    steps.push({
+      run: {
+        name: 'TypeScript',
+        command:
+          packageManager === 'yarn'
+            ? 'yarn tsc --noEmit'
+            : 'npm run tsc -- --noEmit',
+      },
+    });
+  }
+
+  if (staticAnalysis.eslint !== false) {
+    steps.push({
+      run: {
+        name: 'ESLint',
+        command:
+          packageManager === 'yarn' ? 'yarn lint' : 'npm run lint',
+      },
+    });
+  }
+
+  if (staticAnalysis.prettier !== false) {
+    steps.push({
+      run: {
+        name: 'Prettier',
+        command:
+          packageManager === 'yarn'
+            ? 'yarn format:check'
+            : 'npm run format:check',
+      },
+    });
+  }
+
+  if (staticAnalysis.unitTests !== false) {
+    steps.push({
+      run: {
+        name: 'Unit Tests',
+        command:
+          packageManager === 'yarn' ? 'yarn test --ci' : 'npm test -- --ci',
+      },
+    });
+  }
+
+  // Slack notification step
+  if (
+    staticAnalysis.notification === 'slack' ||
+    staticAnalysis.notification === 'both'
+  ) {
+    steps.push({
+      'slack/notify': {
+        event: 'always',
+        template: 'basic_success_1',
+      },
+    });
+  }
+
+  // Build branch filters
+  const branchFilter: Record<string, unknown> = {};
+  if (triggers?.push?.branches && triggers.push.branches.length > 0) {
+    branchFilter.only = triggers.push.branches;
+  }
+
+  const jobFilters =
+    Object.keys(branchFilter).length > 0
+      ? { filters: { branches: branchFilter } }
+      : {};
+
+  const orbs: Record<string, string> = {
+    node: 'circleci/node@5',
+  };
+
+  if (
+    staticAnalysis.notification === 'slack' ||
+    staticAnalysis.notification === 'both'
+  ) {
+    orbs.slack = 'circleci/slack@4';
+  }
+
+  return {
+    version: 2.1,
+    orbs,
+    jobs: {
+      'static-analysis': {
+        docker: [{ image: `cimg/node:${nodeVersion}.0` }],
+        steps,
+      },
+    },
+    workflows: {
+      'static-analysis': {
+        jobs: [{ 'static-analysis': jobFilters }],
+      },
+    },
+  };
+}

--- a/src/presets/gitlabBuildPreset.ts
+++ b/src/presets/gitlabBuildPreset.ts
@@ -1,0 +1,149 @@
+import { WorkflowOptions } from '../types';
+import { BuildOptions } from './types';
+
+export function buildGitlabBuildPipeline(
+  opts: WorkflowOptions
+): Record<string, unknown> {
+  const {
+    triggers,
+    nodeVersions = [20],
+    packageManager = 'yarn',
+    framework = 'react-native-cli',
+    build = {
+      platform: 'android',
+      variant: 'release',
+      androidOutputType: 'apk',
+      storage: 'github',
+      notification: 'none',
+      includeStaticAnalysis: false,
+    },
+  } = opts;
+
+  const nodeVersion = nodeVersions[0] ?? 20;
+  const installCmd =
+    packageManager === 'yarn' ? 'yarn install --immutable' : 'npm ci';
+  const buildOpts = build as BuildOptions;
+
+  // Scripts array
+  const script: string[] = [installCmd];
+
+  // Static analysis steps
+  if (buildOpts.includeStaticAnalysis) {
+    script.push(
+      packageManager === 'yarn'
+        ? 'yarn tsc --noEmit'
+        : 'npm run tsc -- --noEmit'
+    );
+    script.push(
+      packageManager === 'yarn' ? 'yarn lint' : 'npm run lint'
+    );
+    script.push(
+      packageManager === 'yarn' ? 'yarn test --ci' : 'npm test -- --ci'
+    );
+  }
+
+  // Build command
+  if (framework === 'expo') {
+    script.push('npm install -g eas-cli');
+    const outputFlag =
+      buildOpts.androidOutputType === 'aab' ? 'production' : 'production-apk';
+    script.push(
+      `eas build --platform android --profile ${outputFlag} --local --non-interactive`
+    );
+  } else {
+    script.push('chmod +x android/gradlew');
+    const variant = buildOpts.variant ?? 'release';
+    const outputType = buildOpts.androidOutputType ?? 'apk';
+
+    if (outputType === 'both') {
+      const apkTask =
+        variant === 'debug' ? 'assembleDebug' : 'assembleRelease';
+      const aabTask = variant === 'debug' ? 'bundleDebug' : 'bundleRelease';
+      script.push(`cd android && ./gradlew ${apkTask} ${aabTask} && cd ..`);
+    } else if (outputType === 'aab') {
+      const task = variant === 'debug' ? 'bundleDebug' : 'bundleRelease';
+      script.push(`cd android && ./gradlew ${task} && cd ..`);
+    } else {
+      const task =
+        variant === 'debug' ? 'assembleDebug' : 'assembleRelease';
+      script.push(`cd android && ./gradlew ${task} && cd ..`);
+    }
+  }
+
+  // Build rules from triggers
+  const rules: Array<Record<string, unknown>> = [];
+
+  if (triggers?.push?.branches && triggers.push.branches.length > 0) {
+    const branchPattern = triggers.push.branches.join('|');
+    rules.push({
+      if: `$CI_COMMIT_BRANCH =~ /(${branchPattern})/`,
+    });
+  }
+
+  if (triggers?.pullRequest) {
+    rules.push({ if: '$CI_PIPELINE_SOURCE == "merge_request_event"' });
+  }
+
+  if (triggers?.schedule) {
+    rules.push({ if: '$CI_PIPELINE_SOURCE == "schedule"' });
+  }
+
+  if (triggers?.workflowDispatch) {
+    rules.push({ if: '$CI_PIPELINE_SOURCE == "web"' });
+  }
+
+  if (rules.length === 0) {
+    rules.push(
+      { if: '$CI_PIPELINE_SOURCE == "push"' },
+      { if: '$CI_PIPELINE_SOURCE == "merge_request_event"' }
+    );
+  }
+
+  // Artifact paths
+  const artifactPaths: string[] = [];
+  const outputType = buildOpts.androidOutputType ?? 'apk';
+  if (framework === 'expo') {
+    artifactPaths.push('expo-builds/');
+  } else {
+    if (outputType === 'apk' || outputType === 'both') {
+      artifactPaths.push('android/app/build/outputs/apk/**/*.apk');
+    }
+    if (outputType === 'aab' || outputType === 'both') {
+      artifactPaths.push('android/app/build/outputs/bundle/**/*.aab');
+    }
+  }
+
+  // Slack notification
+  const afterScript: string[] = [];
+  if (
+    buildOpts.notification === 'slack' ||
+    buildOpts.notification === 'both'
+  ) {
+    afterScript.push(
+      `curl -s -X POST -H 'Content-type: application/json' ` +
+        `--data '{"text":"Android build completed on branch: $CI_COMMIT_BRANCH"}' ` +
+        `"$SLACK_WEBHOOK_URL" || true`
+    );
+  }
+
+  const job: Record<string, unknown> = {
+    image: `node:${nodeVersion}`,
+    stage: 'build',
+    cache: {
+      key: '$CI_COMMIT_REF_SLUG',
+      paths: ['node_modules/'],
+    },
+    script,
+    artifacts: {
+      paths: artifactPaths,
+      expire_in: '30 days',
+    },
+    ...(afterScript.length > 0 ? { after_script: afterScript } : {}),
+    rules,
+  };
+
+  return {
+    stages: ['build'],
+    build: job,
+  };
+}

--- a/src/presets/gitlabStaticAnalysis.ts
+++ b/src/presets/gitlabStaticAnalysis.ts
@@ -1,0 +1,108 @@
+import { WorkflowOptions } from '../types';
+
+export function buildGitlabStaticAnalysisPipeline(
+  opts: WorkflowOptions
+): Record<string, unknown> {
+  const {
+    triggers,
+    nodeVersions = [20],
+    packageManager = 'yarn',
+    staticAnalysis = {
+      typescript: true,
+      eslint: true,
+      prettier: true,
+      unitTests: true,
+    },
+  } = opts;
+
+  const nodeVersion = nodeVersions[0] ?? 20;
+  const installCmd =
+    packageManager === 'yarn' ? 'yarn install --immutable' : 'npm ci';
+
+  const script: string[] = [installCmd];
+
+  if (staticAnalysis.typescript !== false) {
+    script.push(
+      packageManager === 'yarn'
+        ? 'yarn tsc --noEmit'
+        : 'npm run tsc -- --noEmit'
+    );
+  }
+  if (staticAnalysis.eslint !== false) {
+    script.push(
+      packageManager === 'yarn' ? 'yarn lint' : 'npm run lint'
+    );
+  }
+  if (staticAnalysis.prettier !== false) {
+    script.push(
+      packageManager === 'yarn'
+        ? 'yarn format:check'
+        : 'npm run format:check'
+    );
+  }
+  if (staticAnalysis.unitTests !== false) {
+    script.push(
+      packageManager === 'yarn' ? 'yarn test --ci' : 'npm test -- --ci'
+    );
+  }
+
+  // Build rules from triggers
+  const rules: Array<Record<string, unknown>> = [];
+
+  if (triggers?.push?.branches && triggers.push.branches.length > 0) {
+    const branchPattern = triggers.push.branches.join('|');
+    rules.push({
+      if: `$CI_COMMIT_BRANCH =~ /(${branchPattern})/`,
+    });
+  }
+
+  if (triggers?.pullRequest) {
+    rules.push({ if: '$CI_PIPELINE_SOURCE == "merge_request_event"' });
+  }
+
+  if (triggers?.schedule) {
+    rules.push({ if: '$CI_PIPELINE_SOURCE == "schedule"' });
+  }
+
+  if (triggers?.workflowDispatch) {
+    rules.push({ if: '$CI_PIPELINE_SOURCE == "web"' });
+  }
+
+  // Default rules when none configured
+  if (rules.length === 0) {
+    rules.push(
+      { if: '$CI_PIPELINE_SOURCE == "push"' },
+      { if: '$CI_PIPELINE_SOURCE == "merge_request_event"' }
+    );
+  }
+
+  // Slack notification via after_script
+  const afterScript: string[] = [];
+  if (
+    staticAnalysis.notification === 'slack' ||
+    staticAnalysis.notification === 'both'
+  ) {
+    afterScript.push(
+      `curl -s -X POST -H 'Content-type: application/json' ` +
+        `--data '{"text":"Static analysis completed on branch: $CI_COMMIT_BRANCH"}' ` +
+        `"$SLACK_WEBHOOK_URL" || true`
+    );
+  }
+
+  const job: Record<string, unknown> = {
+    image: `node:${nodeVersion}`,
+    stage: 'static-analysis',
+    cache: {
+      key: '$CI_COMMIT_REF_SLUG',
+      paths: ['node_modules/'],
+    },
+    script,
+    ...(afterScript.length > 0 ? { after_script: afterScript } : {}),
+    rules,
+  };
+
+  return {
+    stages: ['static-analysis'],
+    'static-analysis': job,
+  };
+}

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -6,6 +6,8 @@ import { WorkflowOptions } from '../types';
 import { buildBitriseBuildPipeline } from './bitriseBuildPreset';
 import { buildBitriseStaticAnalysisPipeline } from './bitriseStaticAnalysis';
 import { buildBuildPipeline } from './buildPreset';
+import { buildCircleCIBuildPipeline } from './circleciBuilPreset';
+import { buildCircleCIStaticAnalysisPipeline } from './circleciStaticAnalysis';
 import { buildGitlabBuildPipeline } from './gitlabBuildPreset';
 import { buildGitlabStaticAnalysisPipeline } from './gitlabStaticAnalysis';
 import { buildStaticAnalysisPipeline } from './staticAnalysis';
@@ -19,6 +21,8 @@ export function registerBuiltInPresets(): void {
       return buildBitriseStaticAnalysisPipeline(opts);
     } else if (opts.platform === 'gitlab') {
       return buildGitlabStaticAnalysisPipeline(opts);
+    } else if (opts.platform === 'circleci') {
+      return buildCircleCIStaticAnalysisPipeline(opts);
     }
     throw new Error(`Unsupported platform: ${opts.platform}`);
   });
@@ -30,6 +34,8 @@ export function registerBuiltInPresets(): void {
       return buildBitriseBuildPipeline(opts);
     } else if (opts.platform === 'gitlab') {
       return buildGitlabBuildPipeline(opts);
+    } else if (opts.platform === 'circleci') {
+      return buildCircleCIBuildPipeline(opts);
     }
     throw new Error(`Unsupported platform: ${opts.platform}`);
   });
@@ -39,6 +45,8 @@ export function registerBuiltInPresets(): void {
 export * from './bitriseBuildPreset';
 export * from './bitriseStaticAnalysis';
 export * from './buildPreset';
+export * from './circleciBuilPreset';
+export * from './circleciStaticAnalysis';
 export * from './gitlabBuildPreset';
 export * from './gitlabStaticAnalysis';
 export * from './staticAnalysis';

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -6,27 +6,30 @@ import { WorkflowOptions } from '../types';
 import { buildBitriseBuildPipeline } from './bitriseBuildPreset';
 import { buildBitriseStaticAnalysisPipeline } from './bitriseStaticAnalysis';
 import { buildBuildPipeline } from './buildPreset';
+import { buildGitlabBuildPipeline } from './gitlabBuildPreset';
+import { buildGitlabStaticAnalysisPipeline } from './gitlabStaticAnalysis';
 import { buildStaticAnalysisPipeline } from './staticAnalysis';
 
 // Register all built-in presets here
 export function registerBuiltInPresets(): void {
-  // GitHub Actions builders
   registerBuilder('static-analysis', (opts: WorkflowOptions) => {
-    // Default to GitHub Actions if no platform specified
     if (!opts.platform || opts.platform === 'github') {
       return buildStaticAnalysisPipeline(opts);
     } else if (opts.platform === 'bitrise') {
       return buildBitriseStaticAnalysisPipeline(opts);
+    } else if (opts.platform === 'gitlab') {
+      return buildGitlabStaticAnalysisPipeline(opts);
     }
     throw new Error(`Unsupported platform: ${opts.platform}`);
   });
 
   registerBuilder('build', (opts: WorkflowOptions) => {
-    // Default to GitHub Actions if no platform specified
     if (!opts.platform || opts.platform === 'github') {
       return buildBuildPipeline(opts);
     } else if (opts.platform === 'bitrise') {
       return buildBitriseBuildPipeline(opts);
+    } else if (opts.platform === 'gitlab') {
+      return buildGitlabBuildPipeline(opts);
     }
     throw new Error(`Unsupported platform: ${opts.platform}`);
   });
@@ -36,6 +39,8 @@ export function registerBuiltInPresets(): void {
 export * from './bitriseBuildPreset';
 export * from './bitriseStaticAnalysis';
 export * from './buildPreset';
+export * from './gitlabBuildPreset';
+export * from './gitlabStaticAnalysis';
 export * from './staticAnalysis';
 export * from './types';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export type PipelineKind = 'static-analysis' | 'build';
 /**
  * Available CI platforms
  */
-export type CIPlatform = 'github' | 'bitrise';
+export type CIPlatform = 'github' | 'bitrise' | 'gitlab';
 
 /**
  * GitHub Actions workflow trigger configuration

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export type PipelineKind = 'static-analysis' | 'build';
 /**
  * Available CI platforms
  */
-export type CIPlatform = 'github' | 'bitrise' | 'gitlab';
+export type CIPlatform = 'github' | 'bitrise' | 'gitlab' | 'circleci';
 
 /**
  * GitHub Actions workflow trigger configuration

--- a/src/validation/schema.ts
+++ b/src/validation/schema.ts
@@ -90,7 +90,7 @@ function validateWorkflowOptionsSchema(
   if (options.platform !== undefined) {
     validatedOptions.platform = validateEnum(
       options.platform,
-      ['github', 'bitrise'],
+      ['github', 'bitrise', 'gitlab'],
       'platform'
     ) as WorkflowOptions['platform'];
   }

--- a/src/validation/schema.ts
+++ b/src/validation/schema.ts
@@ -90,7 +90,7 @@ function validateWorkflowOptionsSchema(
   if (options.platform !== undefined) {
     validatedOptions.platform = validateEnum(
       options.platform,
-      ['github', 'bitrise', 'gitlab'],
+      ['github', 'bitrise', 'gitlab', 'circleci'],
       'platform'
     ) as WorkflowOptions['platform'];
   }

--- a/src/validation/yaml.ts
+++ b/src/validation/yaml.ts
@@ -913,17 +913,20 @@ function validateWorkflowStructure(parsedYaml: unknown): void {
     throw new Error('Generated workflow is not a valid object');
   }
 
-  // Detect if this is a Bitrise configuration or GitHub Actions workflow
-  if (
-    typeof parsedYaml === 'object' &&
-    parsedYaml &&
-    'format_version' in parsedYaml
-  ) {
-    // This is a Bitrise configuration
-    validateBitriseStructure(parsedYaml as Record<string, unknown>);
-  } else if (typeof parsedYaml === 'object' && parsedYaml) {
-    // This is a GitHub Actions workflow
-    validateGitHubActionsStructure(parsedYaml as Record<string, unknown>);
+  const obj = parsedYaml as Record<string, unknown>;
+
+  // Detect platform by distinctive top-level keys
+  if ('format_version' in obj) {
+    // Bitrise configuration
+    validateBitriseStructure(obj);
+  } else if ('stages' in obj && !('jobs' in obj)) {
+    // GitLab CI — must have at least one stage
+    if (!Array.isArray(obj.stages) || obj.stages.length === 0) {
+      throw new Error('GitLab CI configuration must have at least one stage');
+    }
+  } else {
+    // GitHub Actions workflow
+    validateGitHubActionsStructure(obj);
   }
 }
 

--- a/src/validation/yaml.ts
+++ b/src/validation/yaml.ts
@@ -924,6 +924,11 @@ function validateWorkflowStructure(parsedYaml: unknown): void {
     if (!Array.isArray(obj.stages) || obj.stages.length === 0) {
       throw new Error('GitLab CI configuration must have at least one stage');
     }
+  } else if ('version' in obj && typeof obj.version === 'number' && obj.version >= 2) {
+    // CircleCI config (version: 2 or 2.1)
+    if (!obj.jobs || typeof obj.jobs !== 'object') {
+      throw new Error('CircleCI configuration must have at least one job');
+    }
   } else {
     // GitHub Actions workflow
     validateGitHubActionsStructure(obj);


### PR DESCRIPTION
## Summary
- Adds CircleCI as a selectable platform in the workflow builder (UI dropdown + description text)
- Implements `circleciStaticAnalysis` and `circleciBuilPreset` presets generating `.circleci/config.yml`
- Extends `CIPlatform` type, schema validator, YAML structure validator (detects `version: 2.x`), and generator output paths
- Adds unit tests for both presets and integration tests via `generateWorkflow()` API

## Technical notes
- CircleCI config is detected in the YAML validator by `version` being a number ≥ 2
- Output file: `.circleci/config.yml`
- Uses CircleCI orbs (`circleci/node@5`, optionally `circleci/slack@4`) for dependency management and notifications
- Build preset uses `cimg/android:2024.01` Docker image

> **Note:** This PR stacks on top of `feat/gitlab-ci` (#56). Merge that first, or review the diff scoped to this branch's commits.

## Test plan
- [ ] Select "CircleCI" in the web form and verify a CircleCI config preview is shown
- [ ] Verify `version: 2.1` and `orbs` appear in the preview
- [ ] `yarn test` passes (388 tests)