### PR TITLE
feat(seo): OG tags, Twitter cards, JSON-LD schemas, richer metadata

### DIFF
--- a/app/app/docs/benefits/page.tsx
+++ b/app/app/docs/benefits/page.tsx
@@ -4,10 +4,24 @@ import { Book, CheckCircle, Clock, Target, TrendingUp } from 'lucide-react';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Benefits — React Native CI/CD Workflow Builder',
+  title: 'Benefits & ROI',
   description:
-    'Discover how the React Native CI/CD Workflow Builder saves $2K–15K annually by eliminating manual CI setup and reducing build configuration time.',
+    'See how Mobile CI Builder saves React Native teams $2K–15K annually: 85–95% faster CI setup, zero manual YAML writing, and consistent pipelines across every project.',
   alternates: { canonical: '/docs/benefits' },
+  openGraph: {
+    title: 'Benefits & ROI | Mobile CI Builder',
+    description:
+      'Save $2K–15K annually. 85–95% faster CI setup for React Native teams. Zero manual YAML writing.',
+    url: 'https://www.mobilecibuilder.com/docs/benefits',
+    images: [{ url: '/opengraph-image', width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Benefits & ROI | Mobile CI Builder',
+    description:
+      'Save $2K–15K annually. 85–95% faster CI setup for React Native teams. Zero manual YAML writing.',
+    images: ['/opengraph-image'],
+  },
 };
 
 export default function BenefitsPage() {

--- a/app/app/docs/configuration/page.tsx
+++ b/app/app/docs/configuration/page.tsx
@@ -5,10 +5,24 @@ import { ArrowRight } from 'lucide-react';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Configuration Reference — React Native CI/CD Workflow Builder',
+  title: 'Configuration Reference',
   description:
-    'Complete reference for all workflow configuration options including package manager, platform targets, Node version, and more.',
+    'Complete reference for all React Native CI/CD workflow configuration options — triggers, Node.js versions, package manager, platform targets, build variants, storage, and notifications.',
   alternates: { canonical: '/docs/configuration' },
+  openGraph: {
+    title: 'Configuration Reference | Mobile CI Builder',
+    description:
+      'All workflow configuration options — triggers, Node.js versions, package manager, platform targets, build variants, and more.',
+    url: 'https://www.mobilecibuilder.com/docs/configuration',
+    images: [{ url: '/opengraph-image', width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Configuration Reference | Mobile CI Builder',
+    description:
+      'All workflow configuration options — triggers, Node.js versions, package manager, platform targets, build variants, and more.',
+    images: ['/opengraph-image'],
+  },
 };
 
 export default function ConfigurationPage() {

--- a/app/app/docs/core-concepts/page.tsx
+++ b/app/app/docs/core-concepts/page.tsx
@@ -4,10 +4,24 @@ import Link from 'next/link';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Core Concepts — React Native CI/CD Workflow Builder',
+  title: 'Core Concepts',
   description:
-    'Understand the fundamental concepts behind the React Native CI workflow generator — pipelines, presets, platforms, and configuration.',
+    'Understand how the React Native CI/CD workflow generator works — presets, platforms, pipeline kinds, and the configuration model behind GitHub Actions and Bitrise generation.',
   alternates: { canonical: '/docs/core-concepts' },
+  openGraph: {
+    title: 'Core Concepts | Mobile CI Builder',
+    description:
+      'Understand presets, platforms, and the configuration model behind React Native CI/CD workflow generation.',
+    url: 'https://www.mobilecibuilder.com/docs/core-concepts',
+    images: [{ url: '/opengraph-image', width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Core Concepts | Mobile CI Builder',
+    description:
+      'Understand presets, platforms, and the configuration model behind React Native CI/CD workflow generation.',
+    images: ['/opengraph-image'],
+  },
 };
 
 export default function CoreConceptsPage() {

--- a/app/app/docs/getting-started/page.tsx
+++ b/app/app/docs/getting-started/page.tsx
@@ -3,10 +3,24 @@ import Link from 'next/link';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Getting Started — React Native CI/CD Workflow Builder',
+  title: 'Getting Started',
   description:
-    'Set up your first CI/CD workflow for your React Native app in minutes using our visual builder.',
+    'Set up your first CI/CD workflow for your React Native or Expo app in minutes. Choose a preset, configure options, generate YAML, and drop it into your repo.',
   alternates: { canonical: '/docs/getting-started' },
+  openGraph: {
+    title: 'Getting Started | Mobile CI Builder',
+    description:
+      'Set up your first CI/CD workflow for your React Native or Expo app in minutes. No manual YAML writing required.',
+    url: 'https://www.mobilecibuilder.com/docs/getting-started',
+    images: [{ url: '/opengraph-image', width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Getting Started | Mobile CI Builder',
+    description:
+      'Set up your first CI/CD workflow for your React Native or Expo app in minutes.',
+    images: ['/opengraph-image'],
+  },
 };
 
 export default function GettingStartedPage() {

--- a/app/app/docs/page.tsx
+++ b/app/app/docs/page.tsx
@@ -3,204 +3,245 @@ import { ArrowRight } from 'lucide-react';
 import Link from 'next/link';
 import type { Metadata } from 'next';
 
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    {
+      '@type': 'ListItem',
+      position: 1,
+      name: 'Home',
+      item: 'https://www.mobilecibuilder.com',
+    },
+    {
+      '@type': 'ListItem',
+      position: 2,
+      name: 'Documentation',
+      item: 'https://www.mobilecibuilder.com/docs',
+    },
+  ],
+};
+
 export const metadata: Metadata = {
-  title: 'Documentation — React Native CI/CD Workflow Builder',
+  title: 'Documentation',
   description:
-    'Learn how to generate and configure GitHub Actions and Bitrise CI/CD workflows for your React Native projects.',
+    'Learn how to generate and configure GitHub Actions and Bitrise CI/CD workflows for your React Native and Expo projects. Step-by-step guides, configuration reference, and more.',
   alternates: { canonical: '/docs' },
+  openGraph: {
+    title: 'Documentation | Mobile CI Builder',
+    description:
+      'Learn how to generate and configure GitHub Actions and Bitrise CI/CD workflows for your React Native and Expo projects.',
+    url: 'https://www.mobilecibuilder.com/docs',
+    images: [{ url: '/opengraph-image', width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Documentation | Mobile CI Builder',
+    description:
+      'Learn how to generate and configure GitHub Actions and Bitrise CI/CD workflows for your React Native and Expo projects.',
+    images: ['/opengraph-image'],
+  },
 };
 
 export default function DocsPage() {
   return (
-    <div className="space-y-8">
-      <div>
-        <h1 className="scroll-m-20 text-4xl font-bold tracking-tight">
-          React Native CI Workflow Builder
-        </h1>
-        <p className="mt-2 text-lg text-muted-foreground">
-          Create optimized CI/CD workflows for your React Native projects with
-          our visual builder
-        </p>
-      </div>
-
-      <div>
-        <p className="leading-7">
-          Welcome to the React Native CI Workflow Builder! This web application
-          simplifies the creation of CI/CD workflows for React Native projects
-          through a visual, intuitive interface. Say goodbye to complex YAML
-          syntax and hello to a streamlined workflow configuration experience.
-        </p>
-
-        <div className="my-6 rounded-lg border bg-muted/40 p-5">
-          <h3 className="font-semibold">About This Documentation</h3>
-          <p className="mt-2 text-sm">
-            This documentation is organized into focused sections to help you
-            make the most of the workflow builder:
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
+      <div className="space-y-8">
+        <div>
+          <h1 className="scroll-m-20 text-4xl font-bold tracking-tight">
+            React Native CI Workflow Builder
+          </h1>
+          <p className="mt-2 text-lg text-muted-foreground">
+            Create optimized CI/CD workflows for your React Native projects with
+            our visual builder
           </p>
-          <ul className="ml-6 mt-2 list-disc space-y-1">
-            <li>
-              <strong>Getting Started</strong> - Step-by-step guide for new
-              users
-            </li>
-            <li>
-              <strong>Core Concepts</strong> - Understanding the workflow
-              builder's approach
-            </li>
-            <li>
-              <strong>Workflow Presets</strong> - Available workflow templates
-              and their use cases
-            </li>
-            <li>
-              <strong>Configuration</strong> - Options and settings for
-              customizing your workflows
-            </li>
-            <li>
-              <strong>Storage Options</strong> - Ways to store and distribute
-              your build artifacts
-            </li>
-            <li>
-              <strong>Secrets Management</strong> - Handling sensitive
-              information in your workflows
-            </li>
-          </ul>
+        </div>
+
+        <div>
+          <p className="leading-7">
+            Welcome to the React Native CI Workflow Builder! This web
+            application simplifies the creation of CI/CD workflows for React
+            Native projects through a visual, intuitive interface. Say goodbye
+            to complex YAML syntax and hello to a streamlined workflow
+            configuration experience.
+          </p>
+
+          <div className="my-6 rounded-lg border bg-muted/40 p-5">
+            <h3 className="font-semibold">About This Documentation</h3>
+            <p className="mt-2 text-sm">
+              This documentation is organized into focused sections to help you
+              make the most of the workflow builder:
+            </p>
+            <ul className="ml-6 mt-2 list-disc space-y-1">
+              <li>
+                <strong>Getting Started</strong> - Step-by-step guide for new
+                users
+              </li>
+              <li>
+                <strong>Core Concepts</strong> - Understanding the workflow
+                builder's approach
+              </li>
+              <li>
+                <strong>Workflow Presets</strong> - Available workflow templates
+                and their use cases
+              </li>
+              <li>
+                <strong>Configuration</strong> - Options and settings for
+                customizing your workflows
+              </li>
+              <li>
+                <strong>Storage Options</strong> - Ways to store and distribute
+                your build artifacts
+              </li>
+              <li>
+                <strong>Secrets Management</strong> - Handling sensitive
+                information in your workflows
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <Link
+            href="/docs/benefits"
+            className="group rounded-lg border-2 border-green-200 bg-green-50 p-4 transition-colors hover:bg-green-100 dark:border-green-800 dark:bg-green-900/20 dark:hover:bg-green-900/30"
+          >
+            <div className="mb-1 flex items-center justify-between">
+              <h2 className="text-xl font-semibold text-green-800 dark:text-green-200">
+                ⏰ Time & Cost Savings
+              </h2>
+              <ArrowRight className="h-5 w-5 text-green-600 transition-colors group-hover:text-green-800 dark:text-green-400 dark:group-hover:text-green-200" />
+            </div>
+            <p className="text-green-700 dark:text-green-300">
+              85-95% setup time reduction and helpful for teams setting up CI/CD
+            </p>
+          </Link>
+
+          <Link
+            href="/docs/getting-started"
+            className="group rounded-lg border p-4 transition-colors hover:bg-accent"
+          >
+            <div className="mb-1 flex items-center justify-between">
+              <h2 className="text-xl font-semibold">Getting Started</h2>
+              <ArrowRight className="h-5 w-5 text-muted-foreground transition-colors group-hover:text-foreground" />
+            </div>
+            <p className="text-muted-foreground">
+              Learn how to use the web application to create your first workflow
+              in minutes
+            </p>
+          </Link>
+
+          <Link
+            href="/docs/workflow-presets"
+            className="group rounded-lg border p-4 transition-colors hover:bg-accent"
+          >
+            <div className="mb-1 flex items-center justify-between">
+              <h2 className="text-xl font-semibold">Workflow Types</h2>
+              <ArrowRight className="h-5 w-5 text-muted-foreground transition-colors group-hover:text-foreground" />
+            </div>
+            <p className="text-muted-foreground">
+              Explore available workflow types and their specific features
+            </p>
+          </Link>
+
+          <Link
+            href="/docs/configuration"
+            className="group rounded-lg border p-4 transition-colors hover:bg-accent"
+          >
+            <div className="mb-1 flex items-center justify-between">
+              <h2 className="text-xl font-semibold">Configuration Options</h2>
+              <ArrowRight className="h-5 w-5 text-muted-foreground transition-colors group-hover:text-foreground" />
+            </div>
+            <p className="text-muted-foreground">
+              Detailed guide to all available configuration options in the web
+              app
+            </p>
+          </Link>
+
+          <Link
+            href="/docs/storage-options"
+            className="group rounded-lg border p-4 transition-colors hover:bg-accent"
+          >
+            <div className="mb-1 flex items-center justify-between">
+              <h2 className="text-xl font-semibold">Storage Options</h2>
+              <ArrowRight className="h-5 w-5 text-muted-foreground transition-colors group-hover:text-foreground" />
+            </div>
+            <p className="text-muted-foreground">
+              Learn about different ways to store and distribute your build
+              artifacts
+            </p>
+          </Link>
+
+          <Link
+            href="/docs/secrets-management"
+            className="group rounded-lg border p-4 transition-colors hover:bg-accent"
+          >
+            <div className="mb-1 flex items-center justify-between">
+              <h2 className="text-xl font-semibold">Secrets Management</h2>
+              <ArrowRight className="h-5 w-5 text-muted-foreground transition-colors group-hover:text-foreground" />
+            </div>
+            <p className="text-muted-foreground">
+              How to manage sensitive information for your workflows
+            </p>
+          </Link>
+        </div>
+
+        <div className="rounded-lg border bg-muted/20 p-6">
+          <h2 className="mb-4 text-xl font-semibold">Web App Features</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Card className="p-4">
+              <h3 className="mb-1 font-medium">Visual Configuration</h3>
+              <p className="text-sm text-muted-foreground">
+                Form-based interface with intuitive controls and tooltips for
+                easy workflow configuration
+              </p>
+            </Card>
+
+            <Card className="p-4">
+              <h3 className="mb-1 font-medium">Real-time YAML Preview</h3>
+              <p className="text-sm text-muted-foreground">
+                See the generated workflow YAML in real-time as you configure
+                your workflow
+              </p>
+            </Card>
+
+            <Card className="p-4">
+              <h3 className="mb-1 font-medium">Preset Templates</h3>
+              <p className="text-sm text-muted-foreground">
+                Pre-configured workflow templates for common CI/CD scenarios
+              </p>
+            </Card>
+
+            <Card className="p-4">
+              <h3 className="mb-1 font-medium">Secrets Summary</h3>
+              <p className="text-sm text-muted-foreground">
+                Automatic detection and summary of required secrets based on
+                your configuration
+              </p>
+            </Card>
+
+            <Card className="p-4">
+              <h3 className="mb-1 font-medium">Multi-Platform Support</h3>
+              <p className="text-sm text-muted-foreground">
+                Configure workflows for Android, iOS, or both platforms
+                simultaneously
+              </p>
+            </Card>
+
+            <Card className="p-4">
+              <h3 className="mb-1 font-medium">Theme Options</h3>
+              <p className="text-sm text-muted-foreground">
+                Choose between light and dark mode for comfortable workflow
+                creation
+              </p>
+            </Card>
+          </div>
         </div>
       </div>
-
-      <div className="grid gap-4 md:grid-cols-2">
-        <Link
-          href="/docs/benefits"
-          className="group rounded-lg border-2 border-green-200 bg-green-50 p-4 transition-colors hover:bg-green-100 dark:border-green-800 dark:bg-green-900/20 dark:hover:bg-green-900/30"
-        >
-          <div className="mb-1 flex items-center justify-between">
-            <h2 className="text-xl font-semibold text-green-800 dark:text-green-200">
-              ⏰ Time & Cost Savings
-            </h2>
-            <ArrowRight className="h-5 w-5 text-green-600 transition-colors group-hover:text-green-800 dark:text-green-400 dark:group-hover:text-green-200" />
-          </div>
-          <p className="text-green-700 dark:text-green-300">
-            85-95% setup time reduction and helpful for teams setting up CI/CD
-          </p>
-        </Link>
-
-        <Link
-          href="/docs/getting-started"
-          className="group rounded-lg border p-4 transition-colors hover:bg-accent"
-        >
-          <div className="mb-1 flex items-center justify-between">
-            <h2 className="text-xl font-semibold">Getting Started</h2>
-            <ArrowRight className="h-5 w-5 text-muted-foreground transition-colors group-hover:text-foreground" />
-          </div>
-          <p className="text-muted-foreground">
-            Learn how to use the web application to create your first workflow
-            in minutes
-          </p>
-        </Link>
-
-        <Link
-          href="/docs/workflow-presets"
-          className="group rounded-lg border p-4 transition-colors hover:bg-accent"
-        >
-          <div className="mb-1 flex items-center justify-between">
-            <h2 className="text-xl font-semibold">Workflow Types</h2>
-            <ArrowRight className="h-5 w-5 text-muted-foreground transition-colors group-hover:text-foreground" />
-          </div>
-          <p className="text-muted-foreground">
-            Explore available workflow types and their specific features
-          </p>
-        </Link>
-
-        <Link
-          href="/docs/configuration"
-          className="group rounded-lg border p-4 transition-colors hover:bg-accent"
-        >
-          <div className="mb-1 flex items-center justify-between">
-            <h2 className="text-xl font-semibold">Configuration Options</h2>
-            <ArrowRight className="h-5 w-5 text-muted-foreground transition-colors group-hover:text-foreground" />
-          </div>
-          <p className="text-muted-foreground">
-            Detailed guide to all available configuration options in the web app
-          </p>
-        </Link>
-
-        <Link
-          href="/docs/storage-options"
-          className="group rounded-lg border p-4 transition-colors hover:bg-accent"
-        >
-          <div className="mb-1 flex items-center justify-between">
-            <h2 className="text-xl font-semibold">Storage Options</h2>
-            <ArrowRight className="h-5 w-5 text-muted-foreground transition-colors group-hover:text-foreground" />
-          </div>
-          <p className="text-muted-foreground">
-            Learn about different ways to store and distribute your build
-            artifacts
-          </p>
-        </Link>
-
-        <Link
-          href="/docs/secrets-management"
-          className="group rounded-lg border p-4 transition-colors hover:bg-accent"
-        >
-          <div className="mb-1 flex items-center justify-between">
-            <h2 className="text-xl font-semibold">Secrets Management</h2>
-            <ArrowRight className="h-5 w-5 text-muted-foreground transition-colors group-hover:text-foreground" />
-          </div>
-          <p className="text-muted-foreground">
-            How to manage sensitive information for your workflows
-          </p>
-        </Link>
-      </div>
-
-      <div className="rounded-lg border bg-muted/20 p-6">
-        <h2 className="mb-4 text-xl font-semibold">Web App Features</h2>
-        <div className="grid gap-4 sm:grid-cols-2">
-          <Card className="p-4">
-            <h3 className="mb-1 font-medium">Visual Configuration</h3>
-            <p className="text-sm text-muted-foreground">
-              Form-based interface with intuitive controls and tooltips for easy
-              workflow configuration
-            </p>
-          </Card>
-
-          <Card className="p-4">
-            <h3 className="mb-1 font-medium">Real-time YAML Preview</h3>
-            <p className="text-sm text-muted-foreground">
-              See the generated workflow YAML in real-time as you configure your
-              workflow
-            </p>
-          </Card>
-
-          <Card className="p-4">
-            <h3 className="mb-1 font-medium">Preset Templates</h3>
-            <p className="text-sm text-muted-foreground">
-              Pre-configured workflow templates for common CI/CD scenarios
-            </p>
-          </Card>
-
-          <Card className="p-4">
-            <h3 className="mb-1 font-medium">Secrets Summary</h3>
-            <p className="text-sm text-muted-foreground">
-              Automatic detection and summary of required secrets based on your
-              configuration
-            </p>
-          </Card>
-
-          <Card className="p-4">
-            <h3 className="mb-1 font-medium">Multi-Platform Support</h3>
-            <p className="text-sm text-muted-foreground">
-              Configure workflows for Android, iOS, or both platforms
-              simultaneously
-            </p>
-          </Card>
-
-          <Card className="p-4">
-            <h3 className="mb-1 font-medium">Theme Options</h3>
-            <p className="text-sm text-muted-foreground">
-              Choose between light and dark mode for comfortable workflow
-              creation
-            </p>
-          </Card>
-        </div>
-      </div>
-    </div>
+    </>
   );
 }

--- a/app/app/docs/secrets-management/page.tsx
+++ b/app/app/docs/secrets-management/page.tsx
@@ -1,10 +1,24 @@
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Secrets Management — React Native CI/CD Workflow Builder',
+  title: 'Secrets Management',
   description:
-    'Securely handle API keys, signing certificates, and deployment credentials in your React Native CI/CD workflow configurations.',
+    'Securely handle API keys, signing certificates, Firebase credentials, and deployment tokens in GitHub Actions and Bitrise workflows for React Native apps.',
   alternates: { canonical: '/docs/secrets-management' },
+  openGraph: {
+    title: 'Secrets Management | Mobile CI Builder',
+    description:
+      'Securely handle API keys, signing certificates, and deployment credentials in GitHub Actions and Bitrise workflows.',
+    url: 'https://www.mobilecibuilder.com/docs/secrets-management',
+    images: [{ url: '/opengraph-image', width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Secrets Management | Mobile CI Builder',
+    description:
+      'Securely handle API keys, signing certificates, and deployment credentials in GitHub Actions and Bitrise workflows.',
+    images: ['/opengraph-image'],
+  },
 };
 
 export default function SecretsManagementPage() {

--- a/app/app/docs/storage-options/page.tsx
+++ b/app/app/docs/storage-options/page.tsx
@@ -4,10 +4,24 @@ import { ArrowRight } from 'lucide-react';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Storage Options — React Native CI/CD Workflow Builder',
+  title: 'Storage Options',
   description:
-    'Configure where to store your React Native build artifacts — APK, AAB, and IPA — including GitHub Actions artifacts and external storage.',
+    'Configure where to store React Native build artifacts (APK, AAB, IPA) — GitHub Actions artifacts, Firebase App Distribution, Google Drive, or Amazon S3.',
   alternates: { canonical: '/docs/storage-options' },
+  openGraph: {
+    title: 'Storage Options | Mobile CI Builder',
+    description:
+      'Store React Native build artifacts on GitHub Actions, Firebase App Distribution, Google Drive, or Amazon S3.',
+    url: 'https://www.mobilecibuilder.com/docs/storage-options',
+    images: [{ url: '/opengraph-image', width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Storage Options | Mobile CI Builder',
+    description:
+      'Store React Native build artifacts on GitHub Actions, Firebase App Distribution, Google Drive, or Amazon S3.',
+    images: ['/opengraph-image'],
+  },
 };
 
 export default function StorageOptionsPage() {

--- a/app/app/docs/workflow-presets/page.tsx
+++ b/app/app/docs/workflow-presets/page.tsx
@@ -4,10 +4,24 @@ import { Check, AlertCircle, Box, Smartphone } from 'lucide-react';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Workflow Presets — React Native CI/CD Workflow Builder',
+  title: 'Workflow Presets',
   description:
-    'Explore the available CI/CD workflow presets — static analysis and build — and choose the right template for your React Native project.',
+    'Explore the static analysis and build workflow presets for React Native and Expo — TypeScript, ESLint, Prettier, Jest, Android APK/AAB, and iOS builds on GitHub Actions and Bitrise.',
   alternates: { canonical: '/docs/workflow-presets' },
+  openGraph: {
+    title: 'Workflow Presets | Mobile CI Builder',
+    description:
+      'Static analysis and build presets for React Native and Expo on GitHub Actions and Bitrise.',
+    url: 'https://www.mobilecibuilder.com/docs/workflow-presets',
+    images: [{ url: '/opengraph-image', width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Workflow Presets | Mobile CI Builder',
+    description:
+      'Static analysis and build presets for React Native and Expo on GitHub Actions and Bitrise.',
+    images: ['/opengraph-image'],
+  },
 };
 
 export default function WorkflowPresetsPage() {

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -13,18 +13,61 @@ const fontSans = FontSans({
   variable: '--font-sans',
 });
 
+const siteUrl = 'https://www.mobilecibuilder.com';
+const siteTitle = 'React Native CI/CD Workflow Builder';
+const siteDescription =
+  'Generate production-ready GitHub Actions and Bitrise workflows for React Native and Expo apps in minutes. Free, open-source, no account required.';
+
 export const metadata: Metadata = {
-  metadataBase: new URL('https://www.mobilecibuilder.com'),
-  title: 'React Native CI/CD Workflow Builder',
-  description:
-    'Generate GitHub Actions workflows for your React Native projects',
+  metadataBase: new URL(siteUrl),
+  title: {
+    default: siteTitle,
+    template: `%s | Mobile CI Builder`,
+  },
+  description: siteDescription,
+  keywords: [
+    'react native ci cd',
+    'github actions react native',
+    'expo ci cd pipeline',
+    'react native workflow generator',
+    'mobile ci workflow builder',
+    'react native github actions template',
+    'android ios build pipeline',
+    'react native automated testing',
+    'bitrise workflow generator',
+    'mobile devops',
+  ],
+  authors: [{ name: 'Mobile CI Builder' }],
+  creator: 'Mobile CI Builder',
   alternates: {
     canonical: '/',
   },
+  openGraph: {
+    type: 'website',
+    url: siteUrl,
+    title: siteTitle,
+    description: siteDescription,
+    siteName: 'Mobile CI Builder',
+    images: [
+      {
+        url: '/opengraph-image',
+        width: 1200,
+        height: 630,
+        alt: 'React Native CI/CD Workflow Builder — generate GitHub Actions workflows in minutes',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: siteTitle,
+    description: siteDescription,
+    creator: '@KushalAgrawal14',
+    images: ['/opengraph-image'],
+  },
   icons: {
     icon: [
-      { url: '/logo.svg', sizes: '192x192', type: 'image/svg' },
-      { url: '/logo.svg', sizes: '512x512', type: 'image/svg' },
+      { url: '/logo.svg', sizes: '192x192', type: 'image/svg+xml' },
+      { url: '/logo.svg', sizes: '512x512', type: 'image/svg+xml' },
     ],
     apple: [{ url: '/logo.svg' }],
   },

--- a/app/app/opengraph-image.tsx
+++ b/app/app/opengraph-image.tsx
@@ -1,0 +1,125 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+export const alt =
+  'React Native CI/CD Workflow Builder — generate GitHub Actions workflows in minutes';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          backgroundColor: '#0f172a',
+          padding: '60px 72px',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        {/* Top accent bar */}
+        <div
+          style={{
+            display: 'flex',
+            width: '80px',
+            height: '4px',
+            borderRadius: '2px',
+            background: 'linear-gradient(90deg, #6366f1, #8b5cf6)',
+            marginBottom: '40px',
+          }}
+        />
+
+        {/* Badge row */}
+        <div style={{ display: 'flex', gap: '12px', marginBottom: '32px' }}>
+          {['Open Source', 'Free', 'No Sign-up'].map(label => (
+            <div
+              key={label}
+              style={{
+                display: 'flex',
+                padding: '6px 16px',
+                borderRadius: '9999px',
+                border: '1px solid #334155',
+                color: '#94a3b8',
+                fontSize: '14px',
+              }}
+            >
+              {label}
+            </div>
+          ))}
+        </div>
+
+        {/* Main heading */}
+        <div
+          style={{
+            display: 'flex',
+            fontSize: '56px',
+            fontWeight: 'bold',
+            lineHeight: 1.15,
+            color: '#f1f5f9',
+            maxWidth: '800px',
+            marginBottom: '24px',
+          }}
+        >
+          React Native CI/CD Workflow Builder
+        </div>
+
+        {/* Subtitle */}
+        <div
+          style={{
+            display: 'flex',
+            fontSize: '22px',
+            color: '#94a3b8',
+            maxWidth: '700px',
+            lineHeight: 1.5,
+            marginBottom: '48px',
+          }}
+        >
+          Generate production-ready GitHub Actions and Bitrise workflows for
+          your React Native or Expo app — in minutes, not hours.
+        </div>
+
+        {/* Bottom row: platform tags */}
+        <div style={{ display: 'flex', gap: '16px', marginTop: 'auto' }}>
+          {[
+            { label: 'GitHub Actions', color: '#6366f1' },
+            { label: 'Bitrise', color: '#8b5cf6' },
+            { label: 'React Native', color: '#06b6d4' },
+            { label: 'Expo', color: '#10b981' },
+          ].map(({ label, color }) => (
+            <div
+              key={label}
+              style={{
+                display: 'flex',
+                padding: '8px 18px',
+                borderRadius: '8px',
+                backgroundColor: '#1e293b',
+                color,
+                fontSize: '15px',
+                fontWeight: '600',
+              }}
+            >
+              {label}
+            </div>
+          ))}
+        </div>
+
+        {/* Domain watermark */}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: '48px',
+            right: '72px',
+            color: '#475569',
+            fontSize: '16px',
+          }}
+        >
+          mobilecibuilder.com
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -5,15 +5,54 @@ import { HeroSection } from '@/components/hero-section';
 import { SupportedFrameworks } from '@/components/supported-frameworks';
 import { WorkflowBuilder } from '@/components/workflow-builder';
 
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'React Native CI/CD Workflow Builder',
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'Web',
+  url: 'https://www.mobilecibuilder.com',
+  description:
+    'Generate production-ready GitHub Actions and Bitrise CI/CD workflows for React Native and Expo apps in minutes. Free, open-source, no account required.',
+  offers: {
+    '@type': 'Offer',
+    price: '0',
+    priceCurrency: 'USD',
+  },
+  featureList: [
+    'GitHub Actions workflow generation',
+    'Bitrise workflow generation',
+    'React Native CI/CD pipeline',
+    'Expo build automation',
+    'Static analysis pipeline',
+    'Android and iOS build workflows',
+    'Artifact storage configuration',
+    'Secrets management guidance',
+  ],
+  screenshot: 'https://www.mobilecibuilder.com/opengraph-image',
+  softwareVersion: '0.1.0',
+  author: {
+    '@type': 'Organization',
+    name: 'Mobile CI Builder',
+    url: 'https://www.mobilecibuilder.com',
+  },
+};
+
 export default function HomePage() {
   return (
-    <main className="flex min-h-screen flex-col items-center">
-      <Header />
-      <HeroSection />
-      <BenefitsSection />
-      <WorkflowBuilder />
-      <SupportedFrameworks />
-      <FooterSection />
-    </main>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <main className="flex min-h-screen flex-col items-center">
+        <Header />
+        <HeroSection />
+        <BenefitsSection />
+        <WorkflowBuilder />
+        <SupportedFrameworks />
+        <FooterSection />
+      </main>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- **Root layout**: add `openGraph`, `twitter`, `keywords`, title template (`%s | Mobile CI Builder`), fix SVG MIME type
- **Dynamic OG image** (`app/opengraph-image.tsx`): edge-rendered 1200×630 image via `next/og` `ImageResponse` — no static file needed, always up-to-date
- **Homepage**: embed `SoftwareApplication` JSON-LD (schema.org) with free-tier offer, feature list, and screenshot reference
- **Docs index**: embed `BreadcrumbList` JSON-LD (Home → Documentation)
- **All 7 doc pages**: add `openGraph` + `twitter` blocks with page-specific titles and keyword-rich descriptions; titles now use root template (`Getting Started | Mobile CI Builder`) so the brand suffix is automatic
- **Meta descriptions**: rewritten with higher keyword density across all pages (react native ci cd, github actions, expo, bitrise, android, ios)

## What this fixes
- Zero social-share preview → rich cards with image on Slack, X, LinkedIn
- No rich snippets → Google can now generate SoftwareApplication cards
- Generic title/description → keyword-targeted copy on every page

## Test plan
- [x] `yarn build` passes (OG image edge route appears in output)
- [x] `yarn type-check` passes
- [x] `yarn lint:ci` passes
- [x] `yarn format:check` passes
- [x] CI passes on this PR
- [x] Visit `/opengraph-image` in browser to verify the image renders